### PR TITLE
see #20613 - Split Environment/LinkEnvironment

### DIFF
--- a/src/org/openstreetmap/josm/data/validation/tests/MapCSSTagChecker.java
+++ b/src/org/openstreetmap/josm/data/validation/tests/MapCSSTagChecker.java
@@ -32,6 +32,7 @@ import org.openstreetmap.josm.data.validation.Severity;
 import org.openstreetmap.josm.data.validation.Test;
 import org.openstreetmap.josm.data.validation.TestError;
 import org.openstreetmap.josm.gui.mappaint.Environment;
+import org.openstreetmap.josm.gui.mappaint.Environment.LinkEnvironment;
 import org.openstreetmap.josm.gui.mappaint.MultiCascade;
 import org.openstreetmap.josm.gui.mappaint.mapcss.MapCSSRule;
 import org.openstreetmap.josm.gui.mappaint.mapcss.MapCSSStyleIndex;
@@ -153,7 +154,7 @@ public class MapCSSTagChecker extends Test.TagTest {
             indexData = createMapCSSTagCheckerIndex(checks, includeOtherSeverity, ALL_TESTS);
         }
 
-        Environment env = new Environment(p, new MultiCascade(), Environment.DEFAULT_LAYER, null);
+        final LinkEnvironment env = new LinkEnvironment(new Environment(p, new MultiCascade(), Environment.DEFAULT_LAYER, null));
         env.mpAreaCache = mpAreaCache;
 
         Iterator<MapCSSRule> candidates = indexData.getRuleCandidates(p);
@@ -210,7 +211,7 @@ public class MapCSSTagChecker extends Test.TagTest {
             OsmPrimitive p, boolean includeOtherSeverity, Collection<Set<MapCSSTagCheckerRule>> checksCol) {
         // this variant is only used by the assertion tests
         final List<TestError> r = new ArrayList<>();
-        final Environment env = new Environment(p, new MultiCascade(), Environment.DEFAULT_LAYER, null);
+        final LinkEnvironment env = new LinkEnvironment(new Environment(p, new MultiCascade(), Environment.DEFAULT_LAYER, null));
         env.mpAreaCache = mpAreaCache;
         for (Set<MapCSSTagCheckerRule> schecks : checksCol) {
             for (MapCSSTagCheckerRule check : schecks) {

--- a/src/org/openstreetmap/josm/data/validation/tests/MapCSSTagCheckerRule.java
+++ b/src/org/openstreetmap/josm/data/validation/tests/MapCSSTagCheckerRule.java
@@ -14,6 +14,7 @@ import org.openstreetmap.josm.data.validation.Test;
 import org.openstreetmap.josm.data.validation.TestError;
 import org.openstreetmap.josm.data.validation.tests.MapCSSTagChecker.AssertionConsumer;
 import org.openstreetmap.josm.gui.mappaint.Environment;
+import org.openstreetmap.josm.gui.mappaint.Environment.LinkEnvironment;
 import org.openstreetmap.josm.gui.mappaint.Keyword;
 import org.openstreetmap.josm.gui.mappaint.mapcss.Condition;
 import org.openstreetmap.josm.gui.mappaint.mapcss.Condition.TagCondition;
@@ -380,7 +381,7 @@ final class MapCSSTagCheckerRule implements Predicate<OsmPrimitive> {
      * @param tester           the tester
      * @return an instance of {@link TestError}, or returns null if the primitive does not give rise to an error.
      */
-    List<TestError> getErrorsForPrimitive(OsmPrimitive p, Selector matchingSelector, Environment env, Test tester) {
+    List<TestError> getErrorsForPrimitive(OsmPrimitive p, Selector matchingSelector, LinkEnvironment env, Test tester) {
         List<TestError> res = new ArrayList<>();
         if (matchingSelector != null && !errors.isEmpty()) {
             final Command fix = fixPrimitive(p);

--- a/src/org/openstreetmap/josm/gui/mappaint/mapcss/ConditionFactory.java
+++ b/src/org/openstreetmap/josm/gui/mappaint/mapcss/ConditionFactory.java
@@ -471,10 +471,12 @@ public final class ConditionFactory {
         }
 
         @Override
-        public boolean applies(Environment env) {
-            if (env.index == null) return false;
+        public boolean applies(Environment e) {
+            if (!(e instanceof Environment.LinkEnvironment)) return false;
+            Environment.LinkEnvironment env = (Environment.LinkEnvironment) e;
+            if (env.index < 0) return false;
             if (index.startsWith("-")) {
-                return env.count != null && op.eval(Integer.toString(env.index - env.count), index);
+                return env.count >= 0 && op.eval(Integer.toString(env.index - env.count), index);
             } else {
                 return op.eval(Integer.toString(env.index + 1), index);
             }
@@ -767,7 +769,10 @@ public final class ConditionFactory {
          * @see IPrimitive#hasSameInterestingTags(IPrimitive)
          */
         static boolean sameTags(Environment e) { // NO_UCD (unused code)
-            return e.osm.hasSameInterestingTags(Utils.firstNonNull(e.child, e.parent));
+            if (!(e instanceof Environment.LinkEnvironment)) return false;
+            Environment.LinkEnvironment env = (Environment.LinkEnvironment) e;
+            IPrimitive other = Utils.firstNonNull(env.child, env.parent);
+            return e.osm.hasSameInterestingTags(other);
         }
 
         /**

--- a/src/org/openstreetmap/josm/gui/mappaint/mapcss/ExpressionFactory.java
+++ b/src/org/openstreetmap/josm/gui/mappaint/mapcss/ExpressionFactory.java
@@ -46,7 +46,7 @@ public final class ExpressionFactory {
             Class<?>[] paramTypes = m.getParameterTypes();
             if (paramTypes.length == 1 && paramTypes[0].isArray()) {
                 arrayFunctions.add(m);
-            } else if (paramTypes.length >= 1 && paramTypes[0].equals(Environment.class)) {
+            } else if (paramTypes.length >= 1 && Environment.class.isAssignableFrom(paramTypes[0])) {
                 parameterFunctionsEnv.add(m);
             } else {
                 parameterFunctions.add(m);

--- a/src/org/openstreetmap/josm/gui/mappaint/mapcss/Functions.java
+++ b/src/org/openstreetmap/josm/gui/mappaint/mapcss/Functions.java
@@ -28,6 +28,7 @@ import org.openstreetmap.josm.data.preferences.NamedColorProperty;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.mappaint.Cascade;
 import org.openstreetmap.josm.gui.mappaint.Environment;
+import org.openstreetmap.josm.gui.mappaint.Environment.LinkEnvironment;
 import org.openstreetmap.josm.gui.mappaint.MapPaintStyles;
 import org.openstreetmap.josm.gui.mappaint.mapcss.ExpressionFactory.NullableArguments;
 import org.openstreetmap.josm.io.XmlWriter;
@@ -449,7 +450,9 @@ public final class Functions {
      * @return first non-null value of the key {@code key} from the object's parent(s)
      */
     public static String parent_tag(final Environment env, String key) { // NO_UCD (unused code)
-        if (env.parent == null) {
+        if (!(env instanceof LinkEnvironment)) {
+            return null;
+        } else if (((LinkEnvironment) env).parent == null) {
             if (env.osm != null) {
                 // we don't have a matched parent, so just search all referrers
                 return env.osm.getReferrers().stream()
@@ -459,7 +462,7 @@ public final class Functions {
             }
             return null;
         }
-        return env.parent.get(key);
+        return ((LinkEnvironment) env).parent.get(key);
     }
 
     /**
@@ -471,7 +474,9 @@ public final class Functions {
      * @return a list of non-null values of the key {@code key} from the object's parent(s)
      */
     public static List<String> parent_tags(final Environment env, String key) { // NO_UCD (unused code)
-        if (env.parent == null) {
+        if (!(env instanceof LinkEnvironment)) {
+            return null;
+        } else if (((LinkEnvironment) env).parent == null) {
             if (env.osm != null) {
                 // we don't have a matched parent, so just search all referrers
                 return env.osm.getReferrers().stream().map(parent -> parent.get(key))
@@ -482,7 +487,7 @@ public final class Functions {
             }
             return Collections.emptyList();
         }
-        return Collections.singletonList(env.parent.get(key));
+        return Collections.singletonList(((LinkEnvironment) env).parent.get(key));
     }
 
     /**
@@ -492,7 +497,11 @@ public final class Functions {
      * @return the value of the key {@code key} from the object's child, or {@code null} if there is no child
      */
     public static String child_tag(final Environment env, String key) { // NO_UCD (unused code)
-        return env.child == null ? null : env.child.get(key);
+        if (!(env instanceof LinkEnvironment)) {
+            return null;
+        }
+        IPrimitive child = ((LinkEnvironment) env).child;
+        return child == null ? null : child.get(key);
     }
 
     /**
@@ -504,7 +513,11 @@ public final class Functions {
      * @see IPrimitive#getUniqueId()
      */
     public static Long parent_osm_id(final Environment env) { // NO_UCD (unused code)
-        return env.parent == null ? null : env.parent.getUniqueId();
+        if (!(env instanceof LinkEnvironment)) {
+            return null;
+        }
+        IPrimitive parent = ((LinkEnvironment) env).parent;
+        return parent == null ? null : parent.getUniqueId();
     }
 
     /**
@@ -539,10 +552,10 @@ public final class Functions {
      * @return the index as float. Starts at 1
      */
     public static Float index(final Environment env) { // NO_UCD (unused code)
-        if (env.index == null) {
+        if ((!(env instanceof LinkEnvironment)) || ((LinkEnvironment) env).index < 0) {
             return null;
         }
-        return Float.valueOf(env.index + 1f);
+        return Float.valueOf(((LinkEnvironment) env).index + 1f);
     }
 
     /**

--- a/src/org/openstreetmap/josm/gui/mappaint/mapcss/Selector.java
+++ b/src/org/openstreetmap/josm/gui/mappaint/mapcss/Selector.java
@@ -191,13 +191,13 @@ public interface Selector {
          *
          */
         private class MatchingReferrerFinder implements PrimitiveVisitor {
-            private final Environment e;
+            private final Environment.LinkEnvironment e;
 
             /**
              * Constructor
              * @param e the environment against which we match
              */
-            MatchingReferrerFinder(Environment e) {
+            MatchingReferrerFinder(Environment.LinkEnvironment e) {
                 this.e = e;
             }
 
@@ -250,9 +250,9 @@ public interface Selector {
         }
 
         private abstract static class AbstractFinder implements PrimitiveVisitor {
-            protected final Environment e;
+            protected final Environment.LinkEnvironment e;
 
-            protected AbstractFinder(Environment e) {
+            protected AbstractFinder(Environment.LinkEnvironment e) {
                 this.e = e;
             }
 
@@ -283,7 +283,7 @@ public interface Selector {
                 return !e.osm.equals(p) && p.isUsable();
             }
 
-            protected void addToChildren(Environment e, IPrimitive p) {
+            protected void addToChildren(Environment.LinkEnvironment e, IPrimitive p) {
                 if (e.children == null) {
                     e.children = new LinkedHashSet<>();
                 }
@@ -298,7 +298,7 @@ public interface Selector {
                 w.visitReferrers(innerVisitor);
             }
 
-            MultipolygonOpenEndFinder(Environment e) {
+            MultipolygonOpenEndFinder(Environment.LinkEnvironment e) {
                 super(e);
             }
 
@@ -325,13 +325,13 @@ public interface Selector {
             /** Will contain all way segments, grouped by cells */
             Map<Point2D, List<WaySegment>> cellSegments;
 
-            private CrossingFinder(Environment e) {
+            private CrossingFinder(Environment.LinkEnvironment e) {
                 super(e);
                 CheckParameterUtil.ensureThat(isArea(e.osm), "Only areas are supported");
                 layer = OsmUtils.getLayer(e.osm);
             }
 
-            private Area getAreaEastNorth(IPrimitive p, Environment e) {
+            private Area getAreaEastNorth(IPrimitive p, Environment.LinkEnvironment e) {
                 if (e.mpAreaCache != null && p.isMultipolygon()) {
                     Area a = e.mpAreaCache.get(p);
                     if (a == null) {
@@ -430,7 +430,7 @@ public interface Selector {
         private class ContainsFinder extends AbstractFinder {
             protected List<IPrimitive> toCheck;
 
-            protected ContainsFinder(Environment e) {
+            protected ContainsFinder(Environment.LinkEnvironment e) {
                 super(e);
                 CheckParameterUtil.ensureThat(!(e.osm instanceof INode), "Nodes not supported");
             }
@@ -462,7 +462,7 @@ public interface Selector {
          */
         private class InsideOrEqualFinder extends AbstractFinder {
 
-            protected InsideOrEqualFinder(Environment e) {
+            protected InsideOrEqualFinder(Environment.LinkEnvironment e) {
                 super(e);
             }
 
@@ -514,7 +514,10 @@ public interface Selector {
         }
 
         @Override
-        public boolean matches(Environment e) {
+        public boolean matches(Environment env) {
+
+            if (!(env instanceof Environment.LinkEnvironment)) return false;
+            Environment.LinkEnvironment e = (Environment.LinkEnvironment) env;
 
             if (!right.matches(e))
                 return false;

--- a/test/unit/org/openstreetmap/josm/data/validation/tests/MapCSSTagCheckerTest.java
+++ b/test/unit/org/openstreetmap/josm/data/validation/tests/MapCSSTagCheckerTest.java
@@ -37,6 +37,7 @@ import org.openstreetmap.josm.data.validation.Test.TagTest;
 import org.openstreetmap.josm.data.validation.TestError;
 import org.openstreetmap.josm.data.validation.tests.MapCSSTagChecker.ParseResult;
 import org.openstreetmap.josm.gui.mappaint.Environment;
+import org.openstreetmap.josm.gui.mappaint.Environment.LinkEnvironment;
 import org.openstreetmap.josm.gui.mappaint.MapPaintStyles;
 import org.openstreetmap.josm.gui.mappaint.mapcss.MapCSSStyleSource;
 import org.openstreetmap.josm.gui.mappaint.mapcss.parsergen.ParseException;
@@ -102,7 +103,7 @@ class MapCSSTagCheckerTest {
         new DataSet(n1, n2);
         assertTrue(check.test(n1));
 
-        final Collection<TestError> errors = check.getErrorsForPrimitive(n1, check.whichSelectorMatchesPrimitive(n1), new Environment(), null);
+        final Collection<TestError> errors = check.getErrorsForPrimitive(n1, check.whichSelectorMatchesPrimitive(n1), new LinkEnvironment(), null);
         assertEquals(1, errors.size());
         TestError err = errors.iterator().next();
         assertEquals("deprecated", err.getMessage());

--- a/test/unit/org/openstreetmap/josm/gui/mappaint/mapcss/MapCSSParserTest.java
+++ b/test/unit/org/openstreetmap/josm/gui/mappaint/mapcss/MapCSSParserTest.java
@@ -27,6 +27,7 @@ import org.openstreetmap.josm.data.osm.Relation;
 import org.openstreetmap.josm.data.osm.RelationMember;
 import org.openstreetmap.josm.data.osm.Way;
 import org.openstreetmap.josm.gui.mappaint.Environment;
+import org.openstreetmap.josm.gui.mappaint.Environment.LinkEnvironment;
 import org.openstreetmap.josm.gui.mappaint.MultiCascade;
 import org.openstreetmap.josm.gui.mappaint.mapcss.ConditionFactory.ClassCondition;
 import org.openstreetmap.josm.gui.mappaint.mapcss.ConditionFactory.KeyCondition;
@@ -423,7 +424,7 @@ class MapCSSParserTest {
         w.addNode(n1);
         w.addNode(n2);
 
-        Environment e = new Environment(n2);
+        LinkEnvironment e = new Environment(n2).withLinkContext();
         assertTrue(s1.matches(e));
         assertEquals(n2, e.osm);
         assertEquals(n1, e.child);


### PR DESCRIPTION
Currently, Environment instances require 120 bytes each. Most fields are only relevant for the LINK context.

18.36%->11.30% of allocations in MapCSSTagCheckerPerformanceTest.testCity amount to Environment/LinkEnvironment.