### PR TITLE
JOSM #21591 - Don't suggest ignored tags in autocompletion

### DIFF
--- a/src/org/openstreetmap/josm/gui/dialogs/properties/RecentTagCollection.java
+++ b/src/org/openstreetmap/josm/gui/dialogs/properties/RecentTagCollection.java
@@ -53,7 +53,7 @@ class RecentTagCollection {
     }
 
     public void add(Tag tag) {
-        if (!tagsToIgnore.match(tag)) {
+        if (!isIgnored(tag)) {
             recentTags.put(tag, null);
         }
     }
@@ -68,7 +68,7 @@ class RecentTagCollection {
 
     public void setTagsToIgnore(SearchCompiler.Match tagsToIgnore) {
         this.tagsToIgnore = tagsToIgnore;
-        recentTags.keySet().removeIf(tagsToIgnore::match);
+        recentTags.keySet().removeIf(this::isIgnored);
     }
 
     public void setTagsToIgnore(SearchSetting tagsToIgnore) throws SearchParseError {
@@ -82,5 +82,9 @@ class RecentTagCollection {
                 : settingToUpdate.text + " OR " + forTag;
         setTagsToIgnore(settingToUpdate);
         return settingToUpdate;
+    }
+
+    public boolean isIgnored(Tag tag) {
+        return tagsToIgnore.match(tag);
     }
 }


### PR DESCRIPTION
\+ immediately remove ignored tags from displayed recent tags list

The 'Add tag' dialog allows users to exclude tags from being shown in the recent tags panel. This patch also prevents these ignored tags from being suggested by the autocompletion in the key/value combo box.

https://josm.openstreetmap.de/ticket/21591