### PR TITLE
fix #21634: Download Along: Allow user to configure if there's a confirmation dialog for small number of download requests.

### DIFF
--- a/src/org/openstreetmap/josm/actions/DownloadAlongAction.java
+++ b/src/org/openstreetmap/josm/actions/DownloadAlongAction.java
@@ -125,15 +125,16 @@ public abstract class DownloadAlongAction extends JosmAction {
      * @param gpxDownload Set to true if GPX data should be downloaded
      * @param title the title string for the confirmation dialog
      * @param newLayer Set to true if all areas should be put into a single new layer
+     * @param confirmNumDownloads Require user to confirm if more than this many download requests, otherwise don't ask
      */
     protected static void confirmAndDownloadAreas(Area a, double maxArea, boolean osmDownload, boolean gpxDownload, String title,
-            boolean newLayer) {
+            boolean newLayer, int confirmNumDownloads) {
         List<Rectangle2D> toDownload = new ArrayList<>();
         addToDownload(a, a.getBounds(), toDownload, maxArea);
         if (toDownload.isEmpty()) {
             return;
         }
-        if (toDownload.size() > 1) {
+        if (toDownload.size() > confirmNumDownloads) {
             JPanel msg = new JPanel(new GridBagLayout());
             msg.add(new JLabel(trn(
                     "<html>This action will require {0} individual<br>download request. Do you wish<br>to continue?</html>",
@@ -185,9 +186,10 @@ public abstract class DownloadAlongAction extends JosmAction {
      * @param panel the panel that was displayed to the user and now contains his selections
      * @param confirmTitle the title to display in the confirmation panel
      * @param newLayer Set to true if all areas should be put into a single new layer
+     * @param confirmNumDownloads Require user to confirm if more than this many download requests, otherwise don't ask
      * @return the task or null if canceled by user
      */
-    protected PleaseWaitRunnable createCalcTask(Path2D alongPath, DownloadAlongPanel panel, String confirmTitle, boolean newLayer) {
+    protected PleaseWaitRunnable createCalcTask(Path2D alongPath, DownloadAlongPanel panel, String confirmTitle, boolean newLayer, int confirmNumDownloads) {
         /*
          * Find the average latitude for the data we're contemplating, so we can know how many
          * metres per degree of longitude we have.
@@ -253,7 +255,7 @@ public abstract class DownloadAlongAction extends JosmAction {
                     return;
                 }
                 confirmAndDownloadAreas(new Area(downloadPath), maxArea, panel.isDownloadOsmData(), panel.isDownloadGpxData(),
-                        confirmTitle, newLayer);
+                        confirmTitle, newLayer, confirmNumDownloads);
             }
 
             /**

--- a/src/org/openstreetmap/josm/actions/DownloadAlongWayAction.java
+++ b/src/org/openstreetmap/josm/actions/DownloadAlongWayAction.java
@@ -16,6 +16,7 @@ import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.PleaseWaitRunnable;
 import org.openstreetmap.josm.gui.help.HelpUtil;
 import org.openstreetmap.josm.gui.layer.gpx.DownloadAlongPanel;
+import org.openstreetmap.josm.spi.preferences.Config;
 import org.openstreetmap.josm.tools.Shortcut;
 
 /**
@@ -27,6 +28,9 @@ public class DownloadAlongWayAction extends DownloadAlongAction {
 
     private static final String PREF_DOWNLOAD_ALONG_WAY_DISTANCE = "downloadAlongWay.distance";
     private static final String PREF_DOWNLOAD_ALONG_WAY_AREA = "downloadAlongWay.area";
+
+	// Ask user to confirm the download if there are more than this many requests.
+    private static final String PREF_DOWNLOAD_ALONG_WAY_DL_REQ_CONFIRM = "downloadAlongWay.numDownloadRequestConfirmation";
 
     private static final String PREF_DOWNLOAD_ALONG_WAY_OSM = "downloadAlongWay.download.osm";
     private static final String PREF_DOWNLOAD_ALONG_WAY_GPS = "downloadAlongWay.download.gps";
@@ -71,7 +75,8 @@ public class DownloadAlongWayAction extends DownloadAlongAction {
                 }
             }
         }
-        return createCalcTask(alongPath, panel, tr("Download from OSM along selected ways"), 1 == ret);
+        int confirmNumDownloads = Config.getPref().getInt(PREF_DOWNLOAD_ALONG_WAY_DL_REQ_CONFIRM, 1);
+        return createCalcTask(alongPath, panel, tr("Download from OSM along selected ways"), 1 == ret, confirmNumDownloads);
     }
 
     @Override

--- a/src/org/openstreetmap/josm/gui/layer/gpx/DownloadAlongTrackAction.java
+++ b/src/org/openstreetmap/josm/gui/layer/gpx/DownloadAlongTrackAction.java
@@ -19,6 +19,7 @@ import org.openstreetmap.josm.gui.PleaseWaitRunnable;
 import org.openstreetmap.josm.gui.help.HelpUtil;
 import org.openstreetmap.josm.gui.layer.GpxLayer;
 import org.openstreetmap.josm.gui.layer.Layer;
+import org.openstreetmap.josm.spi.preferences.Config;
 import org.openstreetmap.josm.tools.Utils;
 
 /**
@@ -39,6 +40,9 @@ public class DownloadAlongTrackAction extends DownloadAlongAction implements Lay
     private static final String PREF_DOWNLOAD_ALONG_TRACK_DISTANCE = "downloadAlongTrack.distance";
     private static final String PREF_DOWNLOAD_ALONG_TRACK_AREA = "downloadAlongTrack.area";
     private static final String PREF_DOWNLOAD_ALONG_TRACK_NEAR = "downloadAlongTrack.near";
+	// Ask user to confirm the download if there are more than this many requests.
+    private static final String PREF_DOWNLOAD_ALONG_TRACK_DL_REQ_CONFIRM = "downloadAlongTrack.numDownloadRequestConfirmation";
+
 
     private final transient Collection<GpxData> data;
 
@@ -85,7 +89,8 @@ public class DownloadAlongTrackAction extends DownloadAlongAction implements Lay
                 gpxPath.closePath();
             });
         }
-        return createCalcTask(gpxPath, panel, tr("Download from OSM along this track"), 1 == ret);
+        int confirmNumDownloads = Config.getPref().getInt(PREF_DOWNLOAD_ALONG_TRACK_DL_REQ_CONFIRM, 1);
+        return createCalcTask(gpxPath, panel, tr("Download from OSM along this track"), 1 == ret, confirmNumDownloads);
     }
 
     @Override


### PR DESCRIPTION
DownloadAlong will ask the user to confirm if it wants to make more than 1 download request. With this patch, the user can set a preference (downloadAlongWay.numDownloadRequestConfirmation or downloadAlongTrack.numDownloadRequestConfirmation), and JOSM will not ask for confirmation if it would make less than or equal to this many requests. If this preference isn't set, it's assumed to be 1. i.e. JOSM will require confirmation when it would make more than 1 request, which is the current behaviour.

I made this patch because I don't want the extra step for making (e.g.) 5 requests.

Please feel free to review it and give feedback. I'm not very experienced with java.

see also https://josm.openstreetmap.de/ticket/21634