### PR TITLE
Add railway:signal:position and railway:signal:direction to railway signal preset

### DIFF
--- a/resources/data/defaultpresets.xml
+++ b/resources/data/defaultpresets.xml
@@ -2510,6 +2510,20 @@
         <item name="Railway Signal" icon="presets/transport/railway/signal.svg" type="node" preset_name_label="true">
             <link wiki="Tag:railway=signal" />
             <key key="railway" value="signal" />
+            <combo key="railway:signal:position"
+                   text="Signal position"
+                   de.text="Signalstandort"
+                   values="left,right,bridge"
+                   display_values="left in direction of OSM way,right in direction of OSM way,on a bridge over the tracks"
+                   de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
+            />
+            <combo key="railway:signal:direction"
+                   text="Direction"
+                   de.text="Anzeigerichtung"
+                   values="forward,backward"
+                   display_values="in direction of OSM way,against direction of OSM way"
+                   de.display_values="In Wegrichtung,Entgegen Wegrichtung"
+            />
             <reference ref="ref_operator" />
         </item> <!-- Railway Signal -->
         <item name="Railway milestone" icon="presets/transport/railway/milestone.svg" type="node" preset_name_label="true">


### PR DESCRIPTION
Hi,

I added `railway:signal:position` and `railway:signal:direction` to the railway signal preset in `defaultpresets.xml`. While most josm users won't know specifics about railway signalling, they _can_ say which side of the track a signal is located and which way it's pointing.

I'm pretty sure this is the wrong way to add localization, because de.text isn't used anywhere else in the file. Could someone point me to the right location?

The preset itself is copied from https://github.com/OpenRailwayMap/OpenRailwayMap/blob/master/josm-presets/de-signals-eso.xml