### PR TITLE
JOSM #21840 - Automatically refresh relation editor on external changes

### DIFF
--- a/src/org/openstreetmap/josm/data/conflict/ConflictCollection.java
+++ b/src/org/openstreetmap/josm/data/conflict/ConflictCollection.java
@@ -316,8 +316,8 @@ public class ConflictCollection implements Iterable<Conflict<? extends OsmPrimit
     }
 
     /**
-     * Returns the list of conflicts involving nodes.
-     * @return The list of conflicts involving nodes.
+     * Returns the list of conflicts involving ways.
+     * @return The list of conflicts involving ways.
      * @since 6555
      */
     public final Collection<Conflict<? extends OsmPrimitive>> getWayConflicts() {
@@ -325,8 +325,8 @@ public class ConflictCollection implements Iterable<Conflict<? extends OsmPrimit
     }
 
     /**
-     * Returns the list of conflicts involving nodes.
-     * @return The list of conflicts involving nodes.
+     * Returns the list of conflicts involving relations.
+     * @return The list of conflicts involving relations.
      * @since 6555
      */
     public final Collection<Conflict<? extends OsmPrimitive>> getRelationConflicts() {

--- a/src/org/openstreetmap/josm/gui/dialogs/relation/IRelationEditor.java
+++ b/src/org/openstreetmap/josm/gui/dialogs/relation/IRelationEditor.java
@@ -39,7 +39,29 @@ public interface IRelationEditor {
      *
      * @return true if the currently edited relation has been changed elsewhere.
      */
-    boolean isDirtyRelation();
+    default boolean isDirtyRelation() {
+        return isDirtyRelation(false);
+    }
+
+    /**
+     * Replies true if the currently edited relation has been changed elsewhere.
+     *
+     * In this case a relation editor can't apply updates to the relation directly. Rather,
+     * it has to create a conflict.
+     *
+     * @param ignoreUninterestingTags whether to ignore uninteresting tag changes
+     * @return true if the currently edited relation has been changed elsewhere.
+     */
+    boolean isDirtyRelation(boolean ignoreUninterestingTags);
+
+    /**
+     * Replies true if the relation has been changed in the editor (but not yet applied).
+     *
+     * Reloading data from the relation would cause the pending changes to be lost.
+     *
+     * @return true if the currently edited relation has been changed in the editor.
+     */
+    boolean isDirtyEditor();
 
     /**
      * Reloads data from relation.

--- a/src/org/openstreetmap/josm/gui/dialogs/relation/RelationEditor.java
+++ b/src/org/openstreetmap/josm/gui/dialogs/relation/RelationEditor.java
@@ -147,7 +147,17 @@ public abstract class RelationEditor extends ExtendedDialog implements IRelation
 
     @Override
     public final boolean isDirtyRelation() {
-        return !relation.hasEqualSemanticAttributes(relationSnapshot);
+        return isDirtyRelation(false);
+    }
+
+    @Override
+    public final boolean isDirtyRelation(boolean ignoreUninterestingTags) {
+        if (relation != null && relation.getDataSet() == null &&
+            relationSnapshot != null && relationSnapshot.getDataSet() == null) {
+            return false;
+        }
+
+        return !relation.hasEqualSemanticAttributes(relationSnapshot, ignoreUninterestingTags);
     }
 
     /* ----------------------------------------------------------------------- */

--- a/src/org/openstreetmap/josm/gui/dialogs/relation/actions/RefreshAction.java
+++ b/src/org/openstreetmap/josm/gui/dialogs/relation/actions/RefreshAction.java
@@ -67,17 +67,7 @@ public class RefreshAction extends SavingAction implements CommandQueueListener 
 
     @Override
     public void updateEnabledState() {
-        Relation snapshot = getEditor().getRelationSnapshot();
-        Relation relation = getEditor().getRelation();
-        if (relation != null && relation.getDataSet() == null)
-            relation = null; // see #19915
-        if (relation != null && snapshot != null && snapshot.getDataSet() == null) {
-            // relation was changed outside of the editor
-            // either it was modified or deleted or changed by an undo
-            setEnabled(!snapshot.hasEqualSemanticAttributes(relation, false /* don't ignore uninteresting keys */));
-            return;
-        }
-        setEnabled(false);
+        setEnabled(getEditor().isDirtyRelation());
     }
 
     protected int confirmDiscardDirtyData() {

--- a/src/org/openstreetmap/josm/gui/dialogs/relation/actions/SavingAction.java
+++ b/src/org/openstreetmap/josm/gui/dialogs/relation/actions/SavingAction.java
@@ -192,8 +192,6 @@ abstract class SavingAction extends AbstractRelationEditorAction {
     }
 
     protected boolean isEditorDirty() {
-        Relation snapshot = editorAccess.getEditor().getRelationSnapshot();
-        return (snapshot != null && !getMemberTableModel().hasSameMembersAs(snapshot)) || getTagModel().isDirty()
-                || getEditor().getRelation() == null || getEditor().getRelation().getDataSet() == null;
+        return editorAccess.getEditor().isDirtyEditor();
     }
 }

--- a/test/unit/org/openstreetmap/josm/gui/dialogs/relation/GenericRelationEditorTest.java
+++ b/test/unit/org/openstreetmap/josm/gui/dialogs/relation/GenericRelationEditorTest.java
@@ -59,6 +59,16 @@ public class GenericRelationEditorTest {
             }
 
             @Override
+            public boolean isDirtyRelation(boolean ignoreUninterestingTags) {
+                return false;
+            }
+
+            @Override
+            public boolean isDirtyEditor() {
+                return false;
+            }
+
+            @Override
             public Relation getRelationSnapshot() {
                 return r;
             }


### PR DESCRIPTION
https://josm.openstreetmap.de/ticket/21840

* Relation in editor is automatically refreshed when no changes have been made in the editor yet. 
* Display a warning notification about required conflict resolution otherwise.