### PR TITLE
Drop use of abc from tile.openstreetmap.org urls

### DIFF
--- a/src/org/openstreetmap/josm/gui/bbox/JosmMapViewer.java
+++ b/src/org/openstreetmap/josm/gui/bbox/JosmMapViewer.java
@@ -91,7 +91,7 @@ public class JosmMapViewer extends JMapViewer {
     public static class DefaultOsmTileSourceProvider implements TileSourceProvider {
 
         protected static final StringProperty DEFAULT_OSM_TILE_URL = new StringProperty(
-                "default.osm.tile.source.url", "https://{switch:a,b,c}.tile.openstreetmap.org/{zoom}/{x}/{y}.png");
+                "default.osm.tile.source.url", "https://tile.openstreetmap.org/{zoom}/{x}/{y}.png");
 
         @Override
         public List<TileSource> getTileSources() {

--- a/src/org/openstreetmap/josm/io/remotecontrol/handler/ImageryHandler.java
+++ b/src/org/openstreetmap/josm/io/remotecontrol/handler/ImageryHandler.java
@@ -117,7 +117,7 @@ public class ImageryHandler extends RequestHandler.RawURLParseRequestHandler {
                 ImageryType::getTypeString));
         return new String[] {
             "/imagery?id=Bing",
-            "/imagery?title=osm&type=tms&url=https://a.tile.openstreetmap.org/%7Bzoom%7D/%7Bx%7D/%7By%7D.png",
+            "/imagery?title=osm&type=tms&url=https://tile.openstreetmap.org/%7Bzoom%7D/%7Bx%7D/%7By%7D.png",
             "/imagery?title=landsat&type=wms&url=http://irs.gis-lab.info/?" +
                     "layers=landsat&SRS=%7Bproj%7D&WIDTH=%7Bwidth%7D&HEIGHT=%7Bheight%7D&BBOX=%7Bbbox%7D",
             "/imagery?title=...&type={"+types+"}&url=....[&cookies=...][&min_zoom=...][&max_zoom=...]"

--- a/test/unit/org/openstreetmap/josm/io/remotecontrol/handler/ImageryHandlerTest.java
+++ b/test/unit/org/openstreetmap/josm/io/remotecontrol/handler/ImageryHandlerTest.java
@@ -85,11 +85,11 @@ class ImageryHandlerTest {
     void testBuildImageryInfo() throws Exception {
         String url = "https://localhost/imagery?title=osm"
                 + "&type=tms&min_zoom=3&max_zoom=23&category=osmbasedmap&country_code=XA"
-                + "&url=https://a.tile.openstreetmap.org/%7Bzoom%7D/%7Bx%7D/%7By%7D.png";
+                + "&url=https://tile.openstreetmap.org/%7Bzoom%7D/%7Bx%7D/%7By%7D.png";
         ImageryInfo imageryInfo = newHandler(url).buildImageryInfo();
         assertEquals("osm", imageryInfo.getName());
         assertEquals(ImageryInfo.ImageryType.TMS, imageryInfo.getImageryType());
-        assertEquals("https://a.tile.openstreetmap.org/{zoom}/{x}/{y}.png", imageryInfo.getUrl());
+        assertEquals("https://tile.openstreetmap.org/{zoom}/{x}/{y}.png", imageryInfo.getUrl());
         assertEquals(3, imageryInfo.getMinZoom());
         assertEquals(23, imageryInfo.getMaxZoom());
         assertEquals(ImageryInfo.ImageryCategory.OSMBASEDMAP, imageryInfo.getImageryCategory());


### PR DESCRIPTION
Use tile.openstreetmap.org url instead of the deprecated a/b/c aliases.

Signed-off-by: Grant Slater <git@firefishy.com>