### PR TITLE
Allow selection of relations in relation membership table via middle click

### DIFF
--- a/src/org/openstreetmap/josm/gui/dialogs/properties/PropertiesDialog.java
+++ b/src/org/openstreetmap/josm/gui/dialogs/properties/PropertiesDialog.java
@@ -999,6 +999,25 @@ implements DataSelectionListener, ActiveLayerChangeListener, DataSetListenerAdap
     public class MouseClickWatch extends MouseAdapter {
         @Override
         public void mouseClicked(MouseEvent e) {
+            if (e.getSource() == membershipTable && e.getButton() == MouseEvent.BUTTON2) {
+                int row = membershipTable.rowAtPoint(e.getPoint());
+                if (row > -1) {
+                    final Relation relation = (Relation) membershipData.getValueAt(row, 0);
+                    DataSet ds = OsmDataManager.getInstance().getActiveDataSet();
+
+                    if (ds != null) {
+                        if (e.isShiftDown()) {
+                            ds.addSelected(relation);
+                        } else if (e.isControlDown()) {
+                            ds.toggleSelected(relation);
+                        } else {
+                            ds.setSelected(relation);
+                        }
+                    }
+                }
+                return;
+            }
+
             if (e.getClickCount() < 2) {
                 // single click, clear selection in other table not clicked in
                 if (e.getSource() == tagTable) {


### PR DESCRIPTION
Allow selection of parent relations in relation membership table via a single mouse click, without having to go through the context popup menu