### PR TITLE
JOSM #22378 - Preview object properties on mouse hover

### DIFF
--- a/src/org/openstreetmap/josm/gui/NavigatableComponent.java
+++ b/src/org/openstreetmap/josm/gui/NavigatableComponent.java
@@ -8,6 +8,8 @@ import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.HierarchyEvent;
 import java.awt.event.HierarchyListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.nio.charset.StandardCharsets;
@@ -20,6 +22,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Stack;
 import java.util.TreeMap;
@@ -52,6 +55,7 @@ import org.openstreetmap.josm.data.preferences.IntegerProperty;
 import org.openstreetmap.josm.data.projection.Projection;
 import org.openstreetmap.josm.data.projection.ProjectionChangeListener;
 import org.openstreetmap.josm.data.projection.ProjectionRegistry;
+import org.openstreetmap.josm.gui.PrimitiveHoverListener.PrimitiveHoverEvent;
 import org.openstreetmap.josm.gui.help.Helpful;
 import org.openstreetmap.josm.gui.layer.NativeScaleLayer;
 import org.openstreetmap.josm.gui.layer.NativeScaleLayer.Scale;
@@ -63,6 +67,7 @@ import org.openstreetmap.josm.gui.util.GuiHelper;
 import org.openstreetmap.josm.spi.preferences.Config;
 import org.openstreetmap.josm.tools.Logging;
 import org.openstreetmap.josm.tools.Utils;
+import org.openstreetmap.josm.tools.bugreport.BugReportExceptionHandler;
 
 /**
  * A component that can be navigated by a {@link MapMover}. Used as map view and for the
@@ -149,6 +154,57 @@ public class NavigatableComponent extends JComponent implements Helpful {
         });
     }
 
+    private final CopyOnWriteArrayList<PrimitiveHoverListener> primitiveHoverListeners = new CopyOnWriteArrayList<>();
+    private OsmPrimitive previousHoveredPrimitive;
+    private PrimitiveHoverMouseListener primitiveHoverMouseListenerHelper = new PrimitiveHoverMouseListener();
+
+    /**
+     * Removes a primitive hover listener
+     *
+     * @param listener the listener. Ignored if null or already absent.
+     * @since xxx
+     */
+    public void removePrimitiveHoverListener(PrimitiveHoverListener listener) {
+        primitiveHoverListeners.remove(listener);
+    }
+
+    /**
+     * Adds a primitive hover listener
+     *
+     * @param listener the listener. Ignored if null or already registered.
+     * @since xxx
+     */
+    public void addPrimitiveHoverListener(PrimitiveHoverListener listener) {
+        if (listener != null) {
+            primitiveHoverListeners.addIfAbsent(listener);
+        }
+    }
+
+    /**
+     * Send a {@link PrimitiveHoverEvent} to registered {@link PrimitiveHoverListener}s
+     * @param e primitive hover event information
+     * @since xxx
+     */
+    protected void firePrimitiveHovered(PrimitiveHoverEvent e) {
+        GuiHelper.runInEDT(() -> {
+            for (PrimitiveHoverListener l : primitiveHoverListeners) {
+                try {
+                    l.primitiveHovered(e);
+                } catch (RuntimeException ex) {
+                    Logging.logWithStackTrace(Logging.LEVEL_ERROR, "Error in primitive hover listener", ex);
+                    BugReportExceptionHandler.handleException(ex);
+                }
+            }
+        });
+    }
+
+    private void updateHoveredPrimitive(OsmPrimitive hovered, MouseEvent e) {
+        if (!Objects.equals(hovered, previousHoveredPrimitive)) {
+            firePrimitiveHovered(new PrimitiveHoverEvent(hovered, previousHoveredPrimitive, e));
+            previousHoveredPrimitive = hovered;
+        }
+    }
+
     // The only events that may move/resize this map view are window movements or changes to the map view size.
     // We can clean this up more by only recalculating the state on repaint.
     private final transient HierarchyListener hierarchyListener = e -> {
@@ -198,6 +254,7 @@ public class NavigatableComponent extends JComponent implements Helpful {
         updateLocationState();
         addHierarchyListener(hierarchyListener);
         addComponentListener(componentListener);
+        addPrimitiveHoverMouseListeners();
         super.addNotify();
     }
 
@@ -205,7 +262,18 @@ public class NavigatableComponent extends JComponent implements Helpful {
     public void removeNotify() {
         removeHierarchyListener(hierarchyListener);
         removeComponentListener(componentListener);
+        removePrimitiveHoverMouseListeners();
         super.removeNotify();
+    }
+
+    private void addPrimitiveHoverMouseListeners() {
+        addMouseMotionListener(primitiveHoverMouseListenerHelper);
+        addMouseListener(primitiveHoverMouseListenerHelper);
+    }
+
+    private void removePrimitiveHoverMouseListeners() {
+        removeMouseMotionListener(primitiveHoverMouseListenerHelper);
+        removeMouseListener(primitiveHoverMouseListenerHelper);
     }
 
     /**
@@ -1714,5 +1782,22 @@ public class NavigatableComponent extends JComponent implements Helpful {
             world.maxNorth-world.minNorth,
             world.maxEast-world.minEast
         )/512;
+    }
+
+    /**
+     * Listener for mouse movement events. Used to detect when primitives are being hovered over with the mouse pointer
+     * so that registered {@link PrimitiveHoverListener}s can be notified.
+     */
+    private class PrimitiveHoverMouseListener extends MouseAdapter {
+        @Override
+        public void mouseMoved(MouseEvent e) {
+            OsmPrimitive hovered = getNearestNodeOrWay(e.getPoint(), isSelectablePredicate, true);
+            updateHoveredPrimitive(hovered, e);
+        }
+
+        @Override
+        public void mouseExited(MouseEvent e) {
+            updateHoveredPrimitive(null, e);
+        }
     }
 }

--- a/src/org/openstreetmap/josm/gui/PrimitiveHoverListener.java
+++ b/src/org/openstreetmap/josm/gui/PrimitiveHoverListener.java
@@ -1,0 +1,68 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.gui;
+
+import java.awt.event.MouseEvent;
+
+import org.openstreetmap.josm.data.osm.IPrimitive;
+
+/**
+ * Interface to notify listeners when the user moves the mouse pointer onto or off of a primitive.
+ * @since xxx
+ */
+@FunctionalInterface
+public interface PrimitiveHoverListener {
+    /**
+     * Method called when the primitive under the mouse pointer changes.
+     * @param e Event object describing the hovered primitive and related information
+     */
+    void primitiveHovered(PrimitiveHoverEvent e);
+
+    /**
+     * Event that is fired when the mouse pointer is moved over a primitive.
+     */
+    class PrimitiveHoverEvent {
+        /**
+         * The primitive that is being hovered over by the mouse pointer.
+         * Can be null if the mouse pointer is not over any primitive.
+         */
+        private final IPrimitive hoveredPrimitive;
+        private final IPrimitive previousPrimitive;
+        private final MouseEvent mouseEvent;
+
+        /**
+         * Construct a new {@code PrimitiveHoverEvent}
+         * @param hoveredPrimitive Primitive that is hovered by the mouse pointer
+         * @param previousPrimitive Previously hovered primitive
+         * @param mouseEvent {@link MouseEvent} that triggered this hover event
+         */
+        public PrimitiveHoverEvent(IPrimitive hoveredPrimitive, IPrimitive previousPrimitive, MouseEvent mouseEvent) {
+            this.hoveredPrimitive = hoveredPrimitive;
+            this.previousPrimitive = previousPrimitive;
+            this.mouseEvent = mouseEvent;
+        }
+
+        /**
+         * Get the primitive that is being hovered over with the mouse pointer
+         * @return The primitive that is being hovered over
+         */
+        public IPrimitive getHoveredPrimitive() {
+            return hoveredPrimitive;
+        }
+
+        /**
+         * Get the previously hovered primitive
+         * @return The previously hovered primitive
+         */
+        public IPrimitive getPreviousPrimitive() {
+            return previousPrimitive;
+        }
+
+        /**
+         * Get the {@link MouseEvent} object that triggered this hover event
+         * @return The {@link MouseEvent} that triggered this hover event
+         */
+        public MouseEvent getMouseEvent() {
+            return mouseEvent;
+        }
+    }
+}

--- a/src/org/openstreetmap/josm/gui/dialogs/properties/PropertiesDialog.java
+++ b/src/org/openstreetmap/josm/gui/dialogs/properties/PropertiesDialog.java
@@ -12,6 +12,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -82,11 +84,15 @@ import org.openstreetmap.josm.data.osm.event.DatasetEventManager.FireMode;
 import org.openstreetmap.josm.data.osm.event.SelectionEventManager;
 import org.openstreetmap.josm.data.osm.search.SearchCompiler;
 import org.openstreetmap.josm.data.osm.search.SearchSetting;
+import org.openstreetmap.josm.data.preferences.AbstractProperty.ValueChangeEvent;
+import org.openstreetmap.josm.data.preferences.AbstractProperty.ValueChangeListener;
 import org.openstreetmap.josm.data.preferences.BooleanProperty;
+import org.openstreetmap.josm.data.preferences.CachingProperty;
 import org.openstreetmap.josm.gui.ConditionalOptionPaneUtil;
 import org.openstreetmap.josm.gui.ExtendedDialog;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.PopupMenuHandler;
+import org.openstreetmap.josm.gui.PrimitiveHoverListener;
 import org.openstreetmap.josm.gui.SideButton;
 import org.openstreetmap.josm.gui.datatransfer.ClipboardUtils;
 import org.openstreetmap.josm.gui.dialogs.ToggleDialog;
@@ -95,6 +101,7 @@ import org.openstreetmap.josm.gui.dialogs.relation.RelationPopupMenus;
 import org.openstreetmap.josm.gui.help.HelpUtil;
 import org.openstreetmap.josm.gui.layer.MainLayerManager.ActiveLayerChangeEvent;
 import org.openstreetmap.josm.gui.layer.MainLayerManager.ActiveLayerChangeListener;
+import org.openstreetmap.josm.gui.layer.Layer;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 import org.openstreetmap.josm.gui.tagging.presets.TaggingPreset;
 import org.openstreetmap.josm.gui.tagging.presets.TaggingPresetHandler;
@@ -139,7 +146,8 @@ import org.openstreetmap.josm.tools.Utils;
  * @author imi
  */
 public class PropertiesDialog extends ToggleDialog
-implements DataSelectionListener, ActiveLayerChangeListener, DataSetListenerAdapter.Listener, TaggingPresetListener {
+implements DataSelectionListener, ActiveLayerChangeListener, PropertyChangeListener, 
+        DataSetListenerAdapter.Listener, TaggingPresetListener, PrimitiveHoverListener {
     private final BooleanProperty PROP_DISPLAY_DISCARDABLE_KEYS = new BooleanProperty("display.discardable-keys", false);
 
     /**
@@ -247,6 +255,18 @@ implements DataSelectionListener, ActiveLayerChangeListener, DataSetListenerAdap
     private static final BooleanProperty PROP_AUTORESIZE_TAGS_TABLE = new BooleanProperty("propertiesdialog.autoresizeTagsTable", false);
 
     /**
+     * Show tags and relation memberships of objects in the properties dialog when hovering over them with the mouse pointer
+     */
+    public static final BooleanProperty PROP_PREVIEW_ON_HOVER = new BooleanProperty("propertiesdialog.preview-on-hover", true);
+    private final HoverPreviewPropListener hoverPreviewPropListener = new HoverPreviewPropListener();
+
+    /**
+     * Always show information for selected objects when something is selected instead of the hovered object
+     */
+    public static final CachingProperty<Boolean> PROP_PREVIEW_ON_HOVER_PRIORITIZE_SELECTION = 
+        new BooleanProperty("propertiesdialog.preview-on-hover.always-show-selected", true).cached();
+
+    /**
      * Create a new PropertiesDialog
      */
     public PropertiesDialog() {
@@ -303,6 +323,8 @@ implements DataSelectionListener, ActiveLayerChangeListener, DataSetListenerAdap
         editHelper.loadTagsIfNeeded();
 
         TaggingPresets.addListener(this);
+
+        PROP_PREVIEW_ON_HOVER.addListener(hoverPreviewPropListener);
     }
 
     @Override
@@ -585,6 +607,8 @@ implements DataSelectionListener, ActiveLayerChangeListener, DataSetListenerAdap
         DatasetEventManager.getInstance().addDatasetListener(dataChangedAdapter, FireMode.IN_EDT_CONSOLIDATED);
         SelectionEventManager.getInstance().addSelectionListenerForEdt(this);
         MainApplication.getLayerManager().addActiveLayerChangeListener(this);
+        if (PROP_PREVIEW_ON_HOVER.get())
+            MainApplication.getMap().mapView.addPrimitiveHoverListener(this);
         for (JosmAction action : josmActions) {
             MainApplication.registerActionShortcut(action);
         }
@@ -596,6 +620,7 @@ implements DataSelectionListener, ActiveLayerChangeListener, DataSetListenerAdap
         DatasetEventManager.getInstance().removeDatasetListener(dataChangedAdapter);
         SelectionEventManager.getInstance().removeSelectionListener(this);
         MainApplication.getLayerManager().removeActiveLayerChangeListener(this);
+        MainApplication.getMap().mapView.removePrimitiveHoverListener(this);
         for (JosmAction action : josmActions) {
             MainApplication.unregisterActionShortcut(action);
         }
@@ -616,6 +641,7 @@ implements DataSelectionListener, ActiveLayerChangeListener, DataSetListenerAdap
         membershipTable.removeMouseListener(popupMenuLauncher);
         super.destroy();
         TaggingPresets.removeListener(this);
+        PROP_PREVIEW_ON_HOVER.removeListener(hoverPreviewPropListener);
         Container parent = pluginHook.getParent();
         if (parent != null) {
             parent.remove(pluginHook);
@@ -635,7 +661,29 @@ implements DataSelectionListener, ActiveLayerChangeListener, DataSetListenerAdap
         // Ignore parameter as we do not want to operate always on real selection here, especially in draw mode
         Collection<? extends IPrimitive> newSel = OsmDataManager.getInstance().getInProgressISelection();
 
+        // Temporarily disable listening to primitive mouse hover events while we have a selection as that takes priority
+        if (PROP_PREVIEW_ON_HOVER.get() && PROP_PREVIEW_ON_HOVER_PRIORITIZE_SELECTION.get()) {
+            if (newSel.isEmpty()) {
+                MainApplication.getMap().mapView.addPrimitiveHoverListener(this);
+            } else {
+                MainApplication.getMap().mapView.removePrimitiveHoverListener(this);
+            }
+        }
+
         updateUi(newSel);
+    }
+
+    @Override
+    public void primitiveHovered(PrimitiveHoverEvent e) {
+        Collection<? extends IPrimitive> selection = OsmDataManager.getInstance().getInProgressISelection();
+        if (PROP_PREVIEW_ON_HOVER_PRIORITIZE_SELECTION.get() && !selection.isEmpty())
+            return;
+
+        if (e.getHoveredPrimitive() != null) {
+            updateUi(e.getHoveredPrimitive());
+        } else {
+            updateUi(selection);
+        }
     }
 
     private void autoresizeTagTable() {
@@ -643,6 +691,11 @@ implements DataSelectionListener, ActiveLayerChangeListener, DataSetListenerAdap
             // resize table's columns to fit content
             TableHelper.computeColumnsWidth(tagTable);
         }
+    }
+
+    private void updateUi(IPrimitive primitive) {
+        updateUi(primitive == null ? Collections.emptyList() :
+                                     Collections.singletonList(primitive));
     }
 
     private void updateUi(Collection<? extends IPrimitive> primitives) {
@@ -829,6 +882,38 @@ implements DataSelectionListener, ActiveLayerChangeListener, DataSetListenerAdap
         }
         // it is time to save history of tags
         updateSelection();
+
+        // Listen for active layer visibility change to enable/disable hover preview
+        // Remove previous listener first (order matters if we are somehow getting a layer change event 
+        // switching from one layer to the same layer)
+        Layer prevLayer = e.getPreviousDataLayer();
+        if (prevLayer != null) {
+            prevLayer.removePropertyChangeListener(this);
+        }
+
+        Layer newLayer = e.getSource().getActiveDataLayer();
+        if (newLayer != null) {
+            newLayer.addPropertyChangeListener(this);
+            if (newLayer.isVisible()) {
+                MainApplication.getMap().mapView.addPrimitiveHoverListener(this);
+            } else {
+                MainApplication.getMap().mapView.removePrimitiveHoverListener(this);
+            }
+        }
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent e) {
+        if (Layer.VISIBLE_PROP.equals(e.getPropertyName())) {
+            boolean isVisible = (boolean) e.getNewValue();
+
+            // Disable hover preview when primitives are invisible
+            if (isVisible) {
+                MainApplication.getMap().mapView.addPrimitiveHoverListener(this);
+            } else {
+                MainApplication.getMap().mapView.removePrimitiveHoverListener(this);
+            }
+        }
     }
 
     @Override
@@ -1435,6 +1520,17 @@ implements DataSelectionListener, ActiveLayerChangeListener, DataSetListenerAdap
         @Override
         public void sorterChanged(RowSorterEvent e) {
             removeHiddenSelection();
+        }
+    }
+
+    private class HoverPreviewPropListener implements ValueChangeListener<Boolean> {
+        @Override
+        public void valueChanged(ValueChangeEvent<? extends Boolean> e) {
+            if (e.getProperty().get() && isDialogShowing()) {
+                MainApplication.getMap().mapView.addPrimitiveHoverListener(PropertiesDialog.this);
+            } else if (!e.getProperty().get()) {
+                MainApplication.getMap().mapView.removePrimitiveHoverListener(PropertiesDialog.this);
+            }
         }
     }
 }

--- a/src/org/openstreetmap/josm/gui/preferences/display/LafPreference.java
+++ b/src/org/openstreetmap/josm/gui/preferences/display/LafPreference.java
@@ -32,6 +32,7 @@ import org.openstreetmap.josm.gui.MapFrame;
 import org.openstreetmap.josm.gui.MapMover;
 import org.openstreetmap.josm.gui.NavigatableComponent;
 import org.openstreetmap.josm.gui.dialogs.ToggleDialog;
+import org.openstreetmap.josm.gui.dialogs.properties.PropertiesDialog;
 
 import org.openstreetmap.josm.gui.preferences.PreferenceSetting;
 import org.openstreetmap.josm.gui.preferences.PreferenceSettingFactory;
@@ -91,6 +92,8 @@ public class LafPreference implements SubPreferenceSetting {
     private final JCheckBox showCoor = new JCheckBox(tr("Show node coordinates in selection lists"));
     private final JCheckBox showLocalizedName = new JCheckBox(tr("Show localized name in selection lists"));
     private final JCheckBox modeless = new JCheckBox(tr("Modeless working (Potlatch style)"));
+    private final JCheckBox previewPropsOnHover = new JCheckBox(tr("Preview object properties on mouse hover"));
+    private final JCheckBox previewPrioritizeSelection = new JCheckBox(tr("Prefer showing information for selected objects"));
     private final JCheckBox dynamicButtons = new JCheckBox(tr("Dynamic buttons in side menus"));
     private final JCheckBox isoDates = new JCheckBox(tr("Display ISO dates"));
     private final JCheckBox dialogGeometry = new JCheckBox(tr("Remember dialog geometries"));
@@ -174,6 +177,16 @@ public class LafPreference implements SubPreferenceSetting {
         panel.add(showLocalizedName, GBC.eop().insets(20, 0, 0, 0));
         panel.add(modeless, GBC.eop().insets(20, 0, 0, 0));
 
+        previewPropsOnHover.setToolTipText(
+                tr("Show tags and relation memberships of objects in the properties dialog when hovering over them with the mouse pointer"));
+        previewPropsOnHover.setSelected(PropertiesDialog.PROP_PREVIEW_ON_HOVER.get());
+        panel.add(previewPropsOnHover, GBC.eop().insets(20, 0, 0, 0));
+
+        previewPrioritizeSelection.setToolTipText(
+            tr("Always show information for selected objects when something is selected instead of the hovered object"));
+        previewPrioritizeSelection.setSelected(PropertiesDialog.PROP_PREVIEW_ON_HOVER_PRIORITIZE_SELECTION.get());
+        panel.add(previewPrioritizeSelection, GBC.eop().insets(40, 0, 0, 0));
+
         dynamicButtons.setToolTipText(tr("Display buttons in right side menus only when mouse is inside the element"));
         dynamicButtons.setSelected(ToggleDialog.PROP_DYNAMIC_BUTTONS.get());
         panel.add(dynamicButtons, GBC.eop().insets(20, 0, 0, 0));
@@ -238,6 +251,8 @@ public class LafPreference implements SubPreferenceSetting {
         Config.getPref().putBoolean("osm-primitives.showcoor", showCoor.isSelected());
         Config.getPref().putBoolean("osm-primitives.localize-name", showLocalizedName.isSelected());
         MapFrame.MODELESS.put(modeless.isSelected());
+        PropertiesDialog.PROP_PREVIEW_ON_HOVER.put(previewPropsOnHover.isSelected());
+        PropertiesDialog.PROP_PREVIEW_ON_HOVER_PRIORITIZE_SELECTION.put(previewPrioritizeSelection.isSelected());
         Config.getPref().putBoolean(ToggleDialog.PROP_DYNAMIC_BUTTONS.getKey(), dynamicButtons.isSelected());
         Config.getPref().putBoolean(DateUtils.PROP_ISO_DATES.getKey(), isoDates.isSelected());
         WindowGeometry.GUI_GEOMETRY_ENABLED.put(dialogGeometry.isSelected());


### PR DESCRIPTION
https://josm.openstreetmap.de/ticket/22378

Show tags and relation memberships of an object in the properties dialog when moving the mouser pointer over it (similar to iD).

Can be enabled/disabled via settings (enabled by default)

An existing selection overrides the hover preview by default, but this behavior can be changed via a setting to always show information about hovered objects.

![josm_mouse_hover_object_preview](https://user-images.githubusercontent.com/8714382/190699113-c2877d57-5ec5-46e8-8085-82b3a794b3ea.gif)
