### PR TITLE
JOSM #22487 - Fix hover preview listener being incorrectly re-added on layer change

### DIFF
--- a/src/org/openstreetmap/josm/gui/dialogs/properties/PropertiesDialog.java
+++ b/src/org/openstreetmap/josm/gui/dialogs/properties/PropertiesDialog.java
@@ -894,7 +894,7 @@ implements DataSelectionListener, ActiveLayerChangeListener, PropertyChangeListe
         Layer newLayer = e.getSource().getActiveDataLayer();
         if (newLayer != null) {
             newLayer.addPropertyChangeListener(this);
-            if (newLayer.isVisible()) {
+            if (newLayer.isVisible() && Boolean.TRUE.equals(PROP_PREVIEW_ON_HOVER.get())) {
                 MainApplication.getMap().mapView.addPrimitiveHoverListener(this);
             } else {
                 MainApplication.getMap().mapView.removePrimitiveHoverListener(this);
@@ -908,7 +908,7 @@ implements DataSelectionListener, ActiveLayerChangeListener, PropertyChangeListe
             boolean isVisible = (boolean) e.getNewValue();
 
             // Disable hover preview when primitives are invisible
-            if (isVisible) {
+            if (isVisible && Boolean.TRUE.equals(PROP_PREVIEW_ON_HOVER.get())) {
                 MainApplication.getMap().mapView.addPrimitiveHoverListener(this);
             } else {
                 MainApplication.getMap().mapView.removePrimitiveHoverListener(this);


### PR DESCRIPTION
Layer (visibility) change listeners did not check if hover preview is disabled and always added the primitive hover listener even if they shouldn't, effectively re-enabling hover preview on layer (visibility) change.

[#22487](https://josm.openstreetmap.de/ticket/22487)