### PR TITLE
JOSM #22750 - Make ImproveWayAccuracyAction extendible

### DIFF
--- a/src/org/openstreetmap/josm/actions/mapmode/ImproveWayAccuracyAction.java
+++ b/src/org/openstreetmap/josm/actions/mapmode/ImproveWayAccuracyAction.java
@@ -274,41 +274,10 @@ public class ImproveWayAccuracyAction extends MapMode implements DataSelectionLi
             // Drawing preview lines and highlighting the node
             // that is going to be moved.
             // Non-native highlighting is used here as well.
-            findEndpoints(g);
-
-            // Drawing preview lines
             MapViewPath b = new MapViewPath(mv);
-            if (alt && !ctrl) {
-                // In delete mode
-                if (endpoint1 != null && endpoint2 != null) {
-                    b.moveTo(endpoint1);
-                    b.lineTo(endpoint2);
-                }
-            } else {
-                // In add or move mode
-                if (endpoint1 != null) {
-                    b.moveTo(mousePos.x, mousePos.y);
-                    b.lineTo(endpoint1);
-                }
-                if (endpoint2 != null) {
-                    b.moveTo(mousePos.x, mousePos.y);
-                    b.lineTo(endpoint2);
-                }
-            }
-            g.draw(b.computeClippedLine(g.getStroke()));
-
-            // Highlighting candidateNode
-            if (candidateNode != null) {
-                g.fill(new MapViewPath(mv).shapeAround(candidateNode, SymbolShape.SQUARE, DOT_SIZE.get()));
-            }
-
-            if (!alt && !ctrl && candidateNode != null) {
-                b.reset();
-                drawIntersectingWayHelperLines(mv, b);
-                g.setStroke(MOVE_NODE_INTERSECTING_STROKE.get());
-                g.draw(b.computeClippedLine(g.getStroke()));
-            }
-
+            findEndpoints(g);
+            drawPreviewLines(g, b);
+            highlightCandidateNode(g, mv, b);
         }
     }
 
@@ -351,6 +320,40 @@ public class ImproveWayAccuracyAction extends MapMode implements DataSelectionLi
                 endpoint2 = targetWay.getNode(nodes.size() - 2);
             }
             // TODO: indicate what part that will be deleted? (for end nodes)
+        }
+    }
+
+    protected void drawPreviewLines(Graphics2D g, MapViewPath b) {
+        if (alt && !ctrl) {
+            // In delete mode
+            if (endpoint1 != null && endpoint2 != null) {
+                b.moveTo(endpoint1);
+                b.lineTo(endpoint2);
+            }
+        } else {
+            // In add or move mode
+            if (endpoint1 != null) {
+                b.moveTo(mousePos.x, mousePos.y);
+                b.lineTo(endpoint1);
+            }
+            if (endpoint2 != null) {
+                b.moveTo(mousePos.x, mousePos.y);
+                b.lineTo(endpoint2);
+            }
+        }
+        g.draw(b.computeClippedLine(g.getStroke()));
+    }
+
+    protected void highlightCandidateNode(Graphics2D g, MapView mv, MapViewPath b) {
+        if (candidateNode != null) {
+            g.fill(new MapViewPath(mv).shapeAround(candidateNode, SymbolShape.SQUARE, DOT_SIZE.get()));
+        }
+
+        if (!alt && !ctrl && candidateNode != null) {
+            b.reset();
+            drawIntersectingWayHelperLines(mv, b);
+            g.setStroke(MOVE_NODE_INTERSECTING_STROKE.get());
+            g.draw(b.computeClippedLine(g.getStroke()));
         }
     }
 

--- a/src/org/openstreetmap/josm/actions/mapmode/ImproveWayAccuracyAction.java
+++ b/src/org/openstreetmap/josm/actions/mapmode/ImproveWayAccuracyAction.java
@@ -74,53 +74,53 @@ import org.openstreetmap.josm.tools.Shortcut;
  */
 public class ImproveWayAccuracyAction extends MapMode implements DataSelectionListener, DataSetListener, ModifierExListener {
 
-    private static final String CROSSHAIR = /* ICON(cursor/)*/ "crosshair";
+    protected static final String CROSSHAIR = /* ICON(cursor/)*/ "crosshair";
 
-    enum State {
+    protected enum State {
         SELECTING, IMPROVING
     }
 
-    private State state;
+    protected State state;
 
-    private MapView mv;
+    protected MapView mv;
 
-    private static final long serialVersionUID = 42L;
+    protected static final long serialVersionUID = 42L;
 
-    private transient Way targetWay;
-    private transient Node candidateNode;
-    private transient WaySegment candidateSegment;
+    protected transient Way targetWay;
+    protected transient Node candidateNode;
+    protected transient WaySegment candidateSegment;
 
-    private Point mousePos;
-    private boolean dragging;
+    protected Point mousePos;
+    protected boolean dragging;
 
-    private final Cursor cursorSelect = ImageProvider.getCursor(/* ICON(cursor/)*/ "normal", /* ICON(cursor/modifier/)*/ "mode");
-    private final Cursor cursorSelectHover = ImageProvider.getCursor(/* ICON(cursor/)*/ "hand", /* ICON(cursor/modifier/)*/ "mode");
-    private final Cursor cursorImprove = ImageProvider.getCursor(CROSSHAIR, null);
-    private final Cursor cursorImproveAdd = ImageProvider.getCursor(CROSSHAIR, /* ICON(cursor/modifier/)*/ "addnode");
-    private final Cursor cursorImproveDelete = ImageProvider.getCursor(CROSSHAIR, /* ICON(cursor/modifier/)*/ "delete_node");
-    private final Cursor cursorImproveAddLock = ImageProvider.getCursor(CROSSHAIR, /* ICON(cursor/modifier/)*/ "add_node_lock");
-    private final Cursor cursorImproveLock = ImageProvider.getCursor(CROSSHAIR, /* ICON(cursor/modifier/)*/ "lock");
+    protected final Cursor cursorSelect = ImageProvider.getCursor(/* ICON(cursor/)*/ "normal", /* ICON(cursor/modifier/)*/ "mode");
+    protected final Cursor cursorSelectHover = ImageProvider.getCursor(/* ICON(cursor/)*/ "hand", /* ICON(cursor/modifier/)*/ "mode");
+    protected final Cursor cursorImprove = ImageProvider.getCursor(CROSSHAIR, null);
+    protected final Cursor cursorImproveAdd = ImageProvider.getCursor(CROSSHAIR, /* ICON(cursor/modifier/)*/ "addnode");
+    protected final Cursor cursorImproveDelete = ImageProvider.getCursor(CROSSHAIR, /* ICON(cursor/modifier/)*/ "delete_node");
+    protected final Cursor cursorImproveAddLock = ImageProvider.getCursor(CROSSHAIR, /* ICON(cursor/modifier/)*/ "add_node_lock");
+    protected final Cursor cursorImproveLock = ImageProvider.getCursor(CROSSHAIR, /* ICON(cursor/modifier/)*/ "lock");
 
-    private Color guideColor;
+    protected Color guideColor;
 
-    private static final CachingProperty<BasicStroke> SELECT_TARGET_WAY_STROKE
+    protected static final CachingProperty<BasicStroke> SELECT_TARGET_WAY_STROKE
             = new StrokeProperty("improvewayaccuracy.stroke.select-target", "2").cached();
-    private static final CachingProperty<BasicStroke> MOVE_NODE_STROKE
+    protected static final CachingProperty<BasicStroke> MOVE_NODE_STROKE
             = new StrokeProperty("improvewayaccuracy.stroke.move-node", "1 6").cached();
-    private static final CachingProperty<BasicStroke> MOVE_NODE_INTERSECTING_STROKE
+    protected static final CachingProperty<BasicStroke> MOVE_NODE_INTERSECTING_STROKE
             = new StrokeProperty("improvewayaccuracy.stroke.move-node-intersecting", "1 2 6").cached();
-    private static final CachingProperty<BasicStroke> ADD_NODE_STROKE
+    protected static final CachingProperty<BasicStroke> ADD_NODE_STROKE
             = new StrokeProperty("improvewayaccuracy.stroke.add-node", "1").cached();
-    private static final CachingProperty<BasicStroke> DELETE_NODE_STROKE
+    protected static final CachingProperty<BasicStroke> DELETE_NODE_STROKE
             = new StrokeProperty("improvewayaccuracy.stroke.delete-node", "1").cached();
-    private static final CachingProperty<Integer> DOT_SIZE
+    protected static final CachingProperty<Integer> DOT_SIZE
             = new IntegerProperty("improvewayaccuracy.dot-size", 6).cached();
 
-    private boolean selectionChangedBlocked;
+    protected boolean selectionChangedBlocked;
 
     protected String oldModeHelpText;
 
-    private final transient AbstractMapViewPaintable temporaryLayer = new AbstractMapViewPaintable() {
+    protected final transient AbstractMapViewPaintable temporaryLayer = new AbstractMapViewPaintable() {
         @Override
         public void paint(Graphics2D g, MapView mv, Bounds bbox) {
             ImproveWayAccuracyAction.this.paint(g, mv, bbox);
@@ -139,6 +139,10 @@ public class ImproveWayAccuracyAction extends MapMode implements DataSelectionLi
                 KeyEvent.VK_W, Shortcut.DIRECT), Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
 
         readPreferences();
+    }
+
+    protected ImproveWayAccuracyAction(String name, String iconName, String tooltip, Shortcut shortcut, Cursor cursor) {
+        super(name, iconName, tooltip, shortcut, cursor);
     }
 
     // -------------------------------------------------------------------------
@@ -540,7 +544,7 @@ public class ImproveWayAccuracyAction extends MapMode implements DataSelectionLi
     /**
      * Sets new cursor depending on state, mouse position
      */
-    private void updateCursor() {
+    protected void updateCursor() {
         if (!isEnabled()) {
             mv.setNewCursor(null, this);
             return;
@@ -640,7 +644,7 @@ public class ImproveWayAccuracyAction extends MapMode implements DataSelectionLi
      * state if a single way or node is selected. Extracts a way by a node in
      * the second case.
      */
-    private void updateStateByCurrentSelection() {
+    protected void updateStateByCurrentSelection() {
         final List<Node> nodeList = new ArrayList<>();
         final List<Way> wayList = new ArrayList<>();
         final DataSet ds = getLayerManager().getEditDataSet();

--- a/src/org/openstreetmap/josm/actions/mapmode/ImproveWayAccuracyAction.java
+++ b/src/org/openstreetmap/josm/actions/mapmode/ImproveWayAccuracyAction.java
@@ -351,13 +351,13 @@ public class ImproveWayAccuracyAction extends MapMode implements DataSelectionLi
 
         if (!alt && !ctrl && candidateNode != null) {
             b.reset();
-            drawIntersectingWayHelperLines(mv, b);
+            drawIntersectingWayHelperLines(b);
             g.setStroke(MOVE_NODE_INTERSECTING_STROKE.get());
             g.draw(b.computeClippedLine(g.getStroke()));
         }
     }
 
-    protected void drawIntersectingWayHelperLines(MapView mv, MapViewPath b) {
+    protected void drawIntersectingWayHelperLines(MapViewPath b) {
         for (final OsmPrimitive referrer : candidateNode.getReferrers()) {
             if (!(referrer instanceof Way) || targetWay.equals(referrer)) {
                 continue;

--- a/src/org/openstreetmap/josm/actions/mapmode/ImproveWayAccuracyAction.java
+++ b/src/org/openstreetmap/josm/actions/mapmode/ImproveWayAccuracyAction.java
@@ -414,8 +414,7 @@ public class ImproveWayAccuracyAction extends MapMode implements DataSelectionLi
             return;
         }
 
-        mousePos = e.getPoint();
-
+        updateMousePosition(e);
         updateKeyModifiers(e);
         updateCursorDependentObjectsIfNeeded();
         updateCursor();
@@ -432,7 +431,7 @@ public class ImproveWayAccuracyAction extends MapMode implements DataSelectionLi
 
         DataSet ds = getLayerManager().getEditDataSet();
         updateKeyModifiers(e);
-        mousePos = e.getPoint();
+        updateMousePosition(e);
 
         if (state == State.SELECTING) {
             if (targetWay != null) {
@@ -547,6 +546,15 @@ public class ImproveWayAccuracyAction extends MapMode implements DataSelectionLi
     // -------------------------------------------------------------------------
     // Custom methods
     // -------------------------------------------------------------------------
+
+    /**
+     * Sets mouse position based on mouse event;
+     * this method allows extending classes to override position
+     */
+    protected void updateMousePosition(MouseEvent e) {
+        mousePos = e.getPoint();
+    }
+
     /**
      * Sets new cursor depending on state, mouse position
      */

--- a/src/org/openstreetmap/josm/actions/mapmode/ImproveWayAccuracyHelper.java
+++ b/src/org/openstreetmap/josm/actions/mapmode/ImproveWayAccuracyHelper.java
@@ -21,9 +21,9 @@ import org.openstreetmap.josm.tools.Pair;
  *
  * @author Alexander Kachkaev &lt;alexander@kachkaev.ru&gt;, 2011
  */
-final class ImproveWayAccuracyHelper {
+class ImproveWayAccuracyHelper {
 
-    private ImproveWayAccuracyHelper() {
+    protected ImproveWayAccuracyHelper() {
         // Hide default constructor for utils classes
     }
 

--- a/src/org/openstreetmap/josm/actions/mapmode/ImproveWayAccuracyHelper.java
+++ b/src/org/openstreetmap/josm/actions/mapmode/ImproveWayAccuracyHelper.java
@@ -69,8 +69,8 @@ class ImproveWayAccuracyHelper {
 
         EastNorth pEN = mv.getEastNorth(p.x, p.y);
 
-        Double bestDistance = Double.MAX_VALUE;
-        Double currentDistance;
+        double bestDistance = Double.MAX_VALUE;
+        double currentDistance;
         List<Pair<Node, Node>> wpps = w.getNodePairs(false);
 
         Node result = null;
@@ -125,10 +125,10 @@ class ImproveWayAccuracyHelper {
 
         EastNorth pEN = mv.getEastNorth(p.x, p.y);
 
-        Double currentDistance;
-        Double currentAngle;
-        Double bestDistance = Double.MAX_VALUE;
-        Double bestAngle = 0.0;
+        double currentDistance;
+        double currentAngle;
+        double bestDistance = Double.MAX_VALUE;
+        double bestAngle = 0.0;
 
         int candidate = -1;
 


### PR DESCRIPTION
[ImproveWay](https://github.com/JOSM/improve-way) plugin used same code base as [ImproveWayAccuracy](https://josm.openstreetmap.de/wiki/Help/Action/ImproveWayAccuracy) mode. Half of code was unnecessary duplication with _old_ code. Moreover, both action in core and plugin needed to be maintained. Common code parts have diverged in years.

This MR makes core action to be extendible. ImproveWay plugin was refactored to extend this class. This change eliminates code duplication.