### PR TITLE
JOSM #22704 - Add `parent_way_angle()` mapcss function

### DIFF
--- a/src/org/openstreetmap/josm/gui/mappaint/mapcss/ExpressionFactory.java
+++ b/src/org/openstreetmap/josm/gui/mappaint/mapcss/ExpressionFactory.java
@@ -216,6 +216,7 @@ public final class ExpressionFactory {
         FACTORY_MAP.put("parent_osm_id", Factory.ofEnv(Functions::parent_osm_id));
         FACTORY_MAP.put("parent_tag", Factory.ofEnv(String.class, Functions::parent_tag));
         FACTORY_MAP.put("parent_tags", Factory.ofEnv(String.class, Functions::parent_tags));
+        FACTORY_MAP.put("parent_way_angle", Factory.ofEnv(Functions::parent_way_angle));
         FACTORY_MAP.put("plus", Factory.ofNumberVarArgs(0.0, DoubleUnaryOperator.identity(), Functions::plus));
         FACTORY_MAP.put("print", Factory.of(Object.class, Functions::print));
         FACTORY_MAP.put("println", Factory.of(Object.class, Functions::println));

--- a/src/org/openstreetmap/josm/gui/mappaint/mapcss/Functions.java
+++ b/src/org/openstreetmap/josm/gui/mappaint/mapcss/Functions.java
@@ -41,6 +41,7 @@ import org.openstreetmap.josm.tools.RotationAngle;
 import org.openstreetmap.josm.tools.StreamUtils;
 import org.openstreetmap.josm.tools.Territories;
 import org.openstreetmap.josm.tools.Utils;
+import org.openstreetmap.josm.tools.RotationAngle.WayDirectionRotationAngle;
 
 /**
  * List of functions that can be used in MapCSS expressions.
@@ -475,6 +476,22 @@ public final class Functions {
             return Collections.emptyList();
         }
         return Collections.singletonList(env.parent.get(key));
+    }
+
+    /**
+     * Get the rotation angle of the preceding parent way segment at the node location.
+     * If there is no preceding parent way segment, the following way segment is used instead.
+     * Requires a parent way object matched via <a href="https://josm.openstreetmap.de/wiki/Help/Styles/MapCSSImplementation#LinkSelector">child selector</a>.
+     * 
+     * @param env the environment
+     * @return the rotation angle of the parent way segment at the node in radians, otherwise null if there is no matching parent way or the object is not a node
+     * @since xxx
+     */
+    public static Double parent_way_angle(final Environment env) {
+        if (env.osm instanceof Node && env.parent instanceof Way) {
+            return WayDirectionRotationAngle.getRotationAngleForNodeOnWay((Node)env.osm, (Way)env.parent);
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
https://josm.openstreetmap.de/ticket/22704

Based on https://github.com/JOSM/josm/pull/109

Add a mapcss function that returns the angle of the parent way section of a node (matched via child element selector) in radians. Similar to the existing `icon-rotation: way;`, just as a function which enables a lot more flexibility.