### PR TITLE
JOSM 22716: Remove duplicate line

### DIFF
--- a/resources/data/validator/geometry.mapcss
+++ b/resources/data/validator/geometry.mapcss
@@ -70,7 +70,6 @@ node[natural=water],
 node[natural=mud],
 node[natural=beach],
 node[natural=sand],
-node[natural=wood],
 node[natural=bare_rock],
 node[natural=glacier],
 node[leisure=park][natural!=tree], /* For nodes with both tags another warning is created in combinations.mapcss */


### PR DESCRIPTION
See https://josm.openstreetmap.de/ticket/22716
Line 66 and 73 both add a warning for `natural=wood` on a node