### PR TITLE
Fix fullscreen mode

### DIFF
--- a/src/org/openstreetmap/josm/actions/DialogsToggleAction.java
+++ b/src/org/openstreetmap/josm/actions/DialogsToggleAction.java
@@ -65,6 +65,7 @@ public class DialogsToggleAction extends ToggleAction {
             if (!Config.getPref().getBoolean("sidetoolbar.always-visible", true) && (!selected || sideToolbarPreviouslyVisible)) {
                 MapFrame.SIDE_TOOLBAR_VISIBLE.put(selected);
             }
+            map.mapView.setMapNavigationComponentVisibility(selected || Config.getPref().getBoolean("navigation.always-visible", true));
             map.mapView.rememberLastPositionOnScreen();
         }
     }

--- a/src/org/openstreetmap/josm/gui/MapFrame.java
+++ b/src/org/openstreetmap/josm/gui/MapFrame.java
@@ -226,7 +226,6 @@ public class MapFrame extends JPanel implements Destroyable, ActiveLayerChangeLi
          */
         splitPane.setDividerSize(5);
         splitPane.setBorder(null);
-        splitPane.setUI(new NoBorderSplitPaneUI());
 
         // JSplitPane supports F6, F8, Home and End shortcuts by default, but we need them for Audio and Image Mapping actions
         InputMap splitInputMap = splitPane.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
@@ -567,24 +566,6 @@ public class MapFrame extends JPanel implements Destroyable, ActiveLayerChangeLi
          */
         if (statusLine != null && Config.getPref().getBoolean("statusline.visible", true)) {
             panel.add(statusLine, BorderLayout.SOUTH);
-        }
-    }
-
-    static final class NoBorderSplitPaneUI extends BasicSplitPaneUI {
-        static final class NoBorderBasicSplitPaneDivider extends BasicSplitPaneDivider {
-            NoBorderBasicSplitPaneDivider(BasicSplitPaneUI ui) {
-                super(ui);
-            }
-
-            @Override
-            public void setBorder(Border b) {
-                // Do nothing
-            }
-        }
-
-        @Override
-        public BasicSplitPaneDivider createDefaultDivider() {
-            return new NoBorderBasicSplitPaneDivider(this);
         }
     }
 

--- a/src/org/openstreetmap/josm/gui/MapView.java
+++ b/src/org/openstreetmap/josm/gui/MapView.java
@@ -1,14 +1,7 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.gui;
 
-import java.awt.AlphaComposite;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.awt.Shape;
+import java.awt.*;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.KeyEvent;
@@ -237,6 +230,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
     private transient MapMover mapMover;
 
     private List<? extends JComponent> mapNavigationComponents;
+    private final Stroke worldBorderStroke = new BasicStroke(1.0f);
 
     /**
      * The listener that listens to invalidations of all layers.
@@ -661,6 +655,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
 
     private void drawWorldBorders(Graphics2D tempG) {
         tempG.setColor(Color.WHITE);
+        tempG.setStroke(worldBorderStroke);
         Bounds b = getProjection().getWorldBoundsLatLon();
 
         int w = getWidth();

--- a/src/org/openstreetmap/josm/gui/MapView.java
+++ b/src/org/openstreetmap/josm/gui/MapView.java
@@ -236,6 +236,8 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
     private Rectangle lastClipBounds = new Rectangle();
     private transient MapMover mapMover;
 
+    private List<? extends JComponent> mapNavigationComponents;
+
     /**
      * The listener that listens to invalidations of all layers.
      */
@@ -293,7 +295,8 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
 
         setFocusTraversalKeysEnabled(!Shortcut.findShortcut(KeyEvent.VK_TAB, 0).isPresent());
 
-        for (JComponent c : getMapNavigationComponents(this)) {
+        mapNavigationComponents = getMapNavigationComponents(this);
+        for (JComponent c : mapNavigationComponents) {
             add(c);
         }
         if (AutoFilterManager.PROP_AUTO_FILTER_ENABLED.get()) {
@@ -910,5 +913,11 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
      */
     public final MapMover getMapMover() {
         return mapMover;
+    }
+
+    public void setMapNavigationComponentVisibility(boolean visible) {
+        for (JComponent c : mapNavigationComponents) {
+            c.setVisible(visible);
+        }
     }
 }

--- a/src/org/openstreetmap/josm/gui/MapView.java
+++ b/src/org/openstreetmap/josm/gui/MapView.java
@@ -1,7 +1,16 @@
 // License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.gui;
 
-import java.awt.*;
+import java.awt.AlphaComposite;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Shape;
+import java.awt.Stroke;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.KeyEvent;


### PR DESCRIPTION
Full screen mode (F11) combined with dialogs off (Tab) produces almost borderless screen. There are some problems:

* 1 pixel border is drawn around map
* 1 pixel border appears in ImproveWayAccuracy mode when State.SELECTING and there is a way under mouse
* zoom control and scale bar at top left corner does not hide

This PR fixes all of them. Result is absolutely borderless, like "Zen mode" in IntelliJ IDEA and Visual Studio Code.