### PR TITLE
make charging station preset usable with areas

### DIFF
--- a/resources/data/defaultpresets.xml
+++ b/resources/data/defaultpresets.xml
@@ -2829,7 +2829,7 @@
             <reference ref="link_contact_address_payment" />
             <preset_link preset_name="Building" />
         </item> <!-- Fuel -->
-        <item name="Charging Station" icon="presets/vehicle/charging_station.svg" type="node" preset_name_label="true">
+        <item name="Charging Station" icon="presets/vehicle/charging_station.svg" type="node,closedway,multipolygon" preset_name_label="true">
             <link wiki="Tag:amenity=charging_station" />
             <space />
             <key key="amenity" value="charging_station" />


### PR DESCRIPTION
compare https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dcharging_station which allows `amenity=charging_station` to be used with nodes and areas but not with ways and relations