### PR TITLE
Update search dialog

### DIFF
--- a/src/org/openstreetmap/josm/gui/dialogs/SearchDialog.java
+++ b/src/org/openstreetmap/josm/gui/dialogs/SearchDialog.java
@@ -231,7 +231,7 @@ public class SearchDialog extends ExtendedDialog {
          * selected preset by the user. Every query is of the form ' group/sub-group/.../presetName'
          * if the corresponding group of the preset exists, otherwise it is simply ' presetName'.
          */
-        selector = new TaggingPresetSelector(false, false);
+        selector = new TaggingPresetSelector(false, false, false);
         selector.setBorder(BorderFactory.createTitledBorder(tr("Search by preset")));
         selector.setDblClickListener(ev -> setPresetDblClickListener(selector, editorComponent));
 

--- a/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPreset.java
+++ b/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPreset.java
@@ -136,6 +136,10 @@ public class TaggingPreset extends AbstractAction implements ActiveLayerChangeLi
      * Show the preset name if true
      */
     public boolean preset_name_label;
+    /**
+     * True if the preset is deprecated
+     */
+    private boolean deprecated = false;
 
     /**
      * The types as preparsed collection.
@@ -347,6 +351,23 @@ public class TaggingPreset extends AbstractAction implements ActiveLayerChangeLi
             Logging.error("Error while parsing" + filter + ": " + e.getMessage());
             throw new SAXException(e);
         }
+    }
+
+    /**
+     * @return true if the preset is deprecated
+     * @apiNote this is not {@code isDeprecated} just in case we decide to make {@link TaggingPreset} a record class.
+     * @since xxx
+     */
+    public final boolean deprecated() {
+        return this.deprecated;
+    }
+
+    /**
+     * Set if the preset is deprecated
+     * @param deprecated if true the preset is deprecated
+     */
+    public final void setDeprecated(boolean deprecated) {
+        this.deprecated = deprecated;
     }
 
     private static class PresetPanel extends JPanel {

--- a/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPresetSearchDialog.java
+++ b/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPresetSearchDialog.java
@@ -34,7 +34,7 @@ public final class TaggingPresetSearchDialog extends ExtendedDialog {
         super(MainApplication.getMainFrame(), tr("Search presets"), tr("Select"), tr("Cancel"));
         setButtonIcons("dialogs/search", "cancel");
         configureContextsensitiveHelp("/Action/TaggingPresetSearch", true /* show help button */);
-        selector = new TaggingPresetSelector(true, true);
+        selector = new TaggingPresetSelector(true, true, true);
         setContent(selector, false);
         SelectionEventManager.getInstance().addSelectionListener(selector);
         selector.setDblClickListener(e -> buttonAction(0, null));

--- a/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPresetSearchPrimitiveDialog.java
+++ b/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPresetSearchPrimitiveDialog.java
@@ -67,7 +67,7 @@ public final class TaggingPresetSearchPrimitiveDialog extends ExtendedDialog {
         super(MainApplication.getMainFrame(), tr("Search for objects by preset"), tr("Search"), tr("Cancel"));
         setButtonIcons("dialogs/search", "cancel");
         configureContextsensitiveHelp("/Action/TaggingPresetSearchPrimitive", true /* show help button */);
-        selector = new TaggingPresetSelector(false, false);
+        selector = new TaggingPresetSelector(false, false, false);
         setContent(selector, false);
         selector.setDblClickListener(e -> buttonAction(0, null));
     }

--- a/test/unit/org/openstreetmap/josm/gui/tagging/presets/PresetClassificationsTest.java
+++ b/test/unit/org/openstreetmap/josm/gui/tagging/presets/PresetClassificationsTest.java
@@ -42,7 +42,7 @@ class PresetClassificationsTest {
     }
 
     private List<PresetClassification> getMatchingPresets(String searchText, OsmPrimitive w) {
-        return classifications.getMatchingPresets(searchText, true, true, EnumSet.of(TaggingPresetType.forPrimitive(w)),
+        return classifications.getMatchingPresets(searchText, true, true, true, EnumSet.of(TaggingPresetType.forPrimitive(w)),
                 Collections.singleton(w));
     }
 


### PR DESCRIPTION
@tsmock

I discussed this with Simon about having a filter for the added attributes. We can also have this for region attributes, although I think it is unnecessary in the case of _deprecated_.

I am having the same issue as with the regions attribute, the validate method in TaggingPresetValidation class is not adding the errors from the _check_ method in TagChecker class.