### PR TITLE
Add support for alternative tagging of the presets.

### DIFF
--- a/resources/data/tagging-preset.xsd
+++ b/resources/data/tagging-preset.xsd
@@ -298,6 +298,13 @@
                 </documentation>
             </annotation>
         </attribute>
+        <attribute name="alternative" type="boolean">
+            <annotation>
+                <documentation>
+                    Indicates that the preset link points to an alternative tagging of the object.
+                </documentation>
+            </annotation>
+        </attribute>
         <attributeGroup ref="tns:attributes.text" />
         <attribute name="name" use="prohibited" />
         <anyAttribute processContents="skip" />

--- a/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPreset.java
+++ b/src/org/openstreetmap/josm/gui/tagging/presets/TaggingPreset.java
@@ -420,6 +420,7 @@ public class TaggingPreset extends AbstractAction implements ActiveLayerChangeLi
         };
         JPanel linkPanel = new JPanel(new GridBagLayout());
         TaggingPresetItem previous = null;
+        boolean alternativeLabel = false; // true if an alternative label has been added
         for (TaggingPresetItem i : data) {
             if (i instanceof Link) {
                 i.addToPanel(linkPanel, itemGuiSupport);
@@ -427,7 +428,10 @@ public class TaggingPreset extends AbstractAction implements ActiveLayerChangeLi
             } else {
                 if (i instanceof PresetLink) {
                     PresetLink link = (PresetLink) i;
-                    if (!(previous instanceof PresetLink && Objects.equals(((PresetLink) previous).text, link.text))) {
+                    if (!alternativeLabel && link.isAlternative()) {
+                        itemPanel.add(link.createAlternativeLabel(), GBC.eol().insets(0, 8, 0, 0));
+                        alternativeLabel = true;
+                    } else if (!(previous instanceof PresetLink && Objects.equals(((PresetLink) previous).text, link.text))) {
                         itemPanel.add(link.createLabel(), GBC.eol().insets(0, 8, 0, 0));
                     }
                 }

--- a/src/org/openstreetmap/josm/gui/tagging/presets/items/PresetLink.java
+++ b/src/org/openstreetmap/josm/gui/tagging/presets/items/PresetLink.java
@@ -45,11 +45,39 @@ public class PresetLink extends TextItem {
     public String preset_name = ""; // NOSONAR
 
     /**
+     * true if the PresetLink points to the alternative tagging of the preset.
+     */
+    private boolean alternative;
+
+    /**
+     * Gets the alternative for the preset
+     */
+    public boolean isAlternative() {
+        return alternative;
+    }
+
+    /**
+     * Sets the alternative for the preset.
+     */
+    public void setAlternative(boolean alternative) {
+        this.alternative = alternative;
+    }
+
+    /**
      * Creates a label to be inserted above this link
      * @return a label
      */
     public JLabel createLabel() {
         initializeLocaleText(tr("Edit also …"));
+        return new JLabel(locale_text);
+    }
+
+    /**
+     * Creates a label to be inserted above the alternative presets
+     * @return a label
+     */
+    public JLabel createAlternativeLabel() {
+        initializeLocaleText(tr("Alternative Presets"));
         return new JLabel(locale_text);
     }
 


### PR DESCRIPTION
Would it be better if we create two separate `List` for storing `PresetLink` objects with alternative="true" and the ones that don't have an alternative tag like presets under the "Edit also" section? 

The current implementation depends on the order in which `preset_link` is defined in the XML file. It does not work if the preset_link with the alternative attribute is defined before the non-alternative ones or between them.