### PR TITLE
Improve Preset for Charging Stations

### DIFF
--- a/resources/data/defaultpresets.xml
+++ b/resources/data/defaultpresets.xml
@@ -2857,10 +2857,6 @@
                 <check key="fee" text="Charging fee" default="on" delete_if_empty="true" />
                 <check key="parking:fee" text="Parking fee" default="" delete_if_empty="true" />
             </checkgroup>
-            <space />
-            <combo key="voltage" text="Voltage" values="230,400"/>
-            <combo key="amperage" text="Amperage" values="16,32" />
-            <space />
             <label text="Types of vehicles which can be charged:" />
             <checkgroup columns="3">
                 <check key="motorcar" text="Cars" default="on" delete_if_empty="true" />
@@ -2877,6 +2873,15 @@
             <text key="socket:chademo" text="CHAdeMO" default="" delete_if_empty="true" />
             <text key="socket:tesla_supercharger" text="Tesla Supercharger" default="" delete_if_empty="true" />
             <text key="socket:schuko" text="Schuko" default="" delete_if_empty="true" />
+            <space />
+            <label text="Charging Power (e.g. '22 kW'):" />
+            <text key="socket:type1:output" text="IEC Type 1" default="" delete_if_empty="true" />
+            <text key="socket:type2:output" text="IEC Type 2 (Mennekes) socket only" default="" delete_if_empty="true" />
+            <text key="socket:type2_cable:output" text="IEC Type 2 (Mennekes) with cable" default="" delete_if_empty="true" />
+            <text key="socket:type2_combo:output" text="IEC Type 2 Combo (CCS)" default="" delete_if_empty="true" />
+            <text key="socket:chademo:output" text="CHAdeMO" default="" delete_if_empty="true" />
+            <text key="socket:tesla_supercharger:output" text="Tesla Supercharger" default="" delete_if_empty="true" />
+            <text key="socket:schuko:output" text="Schuko" default="" delete_if_empty="true" />
             <space />
             <label text="Authentication:" />
             <checkgroup columns="4">

--- a/resources/data/defaultpresets.xml
+++ b/resources/data/defaultpresets.xml
@@ -2862,13 +2862,12 @@
             <combo key="amperage" text="Amperage" values="16,32" />
             <space />
             <label text="Types of vehicles which can be charged:" />
-            <checkgroup columns="4">
-                <check key="bicycle" text="Bicycle" />
-                <check key="scooter" text="Scooter" />
-                <check key="motorcycle" text="Motorcycle" />
-                <check key="motorcar" text="Motorcar" />
-                <check key="truck" text="Truck" />
+            <checkgroup columns="3">
+                <check key="motorcar" text="Cars" default="on" delete_if_empty="true" />
+                <check key="motorcycle" text="Motorcycles" default="on" delete_if_empty="true" />
+                <check key="hgv" text="Trucks (HGV)" default="" delete_if_empty="true" />
             </checkgroup>
+            <label text="(Note: For most charging stations, check 'Cars' and 'Motorcycles'. Check 'Trucks' only if there is sufficient space.)" />
             <space />
             <label text="Number of Sockets:" />
             <combo key="socket:type1" text="SAE J1772 (IEC Type 1)" values="1,2,3,4,5,6" />

--- a/resources/data/defaultpresets.xml
+++ b/resources/data/defaultpresets.xml
@@ -2870,19 +2870,13 @@
             <label text="(Note: For most charging stations, check 'Cars' and 'Motorcycles'. Check 'Trucks' only if there is sufficient space.)" />
             <space />
             <label text="Number of Sockets:" />
-            <combo key="socket:type1" text="SAE J1772 (IEC Type 1)" values="1,2,3,4,5,6" />
-            <combo key="socket:type1_combo" text="SAE J1772 Combo (DC)" values="1,2,3,4,5,6" />
-            <combo key="socket:type2" text="IEC Type 2 (Mennekes)" values="1,2,3,4,5,6" />
-            <combo key="socket:type2_combo" text="IEC Type 2 Combo (DC)" values="1,2,3,4,5,6" />
-            <combo key="socket:type3" text="Type 3 (SCAME)" values="1,2,3,4,5,6" />
-            <combo key="socket:chademo" text="CHAdeMO" values="1,2,3,4,5,6" />
-            <combo key="socket:tesla_supercharger" text="Tesla Supercharger" values="1,2,3,4,5,6" />
-            <combo key="socket:schuko" text="Schuko" values="1,2,3,4,5,6" />
-            <combo key="socket:cee_blue" text="CEE blue" values="1,2,3,4,5,6" />
-            <combo key="socket:cee_red_16a" text="CEE red 16A" values="1,2,3,4,5,6" />
-            <combo key="socket:cee_red_32a" text="CEE red 32A" values="1,2,3,4,5,6" />
-            <combo key="socket:nema_5_15" text="NEMA 5-15" values="1,2,3,4,5,6" />
-            <combo key="socket:nema_5_20" text="NEMA 5-20" values="1,2,3,4,5,6" />
+            <text key="socket:type1" text="IEC Type 1" default="" delete_if_empty="true" />
+            <text key="socket:type2" text="IEC Type 2 (Mennekes) socket only" default="" delete_if_empty="true" />
+            <text key="socket:type2_cable" text="IEC Type 2 (Mennekes) with cable" default="" delete_if_empty="true" />
+            <text key="socket:type2_combo" text="IEC Type 2 Combo (CCS)" default="" delete_if_empty="true" />
+            <text key="socket:chademo" text="CHAdeMO" default="" delete_if_empty="true" />
+            <text key="socket:tesla_supercharger" text="Tesla Supercharger" default="" delete_if_empty="true" />
+            <text key="socket:schuko" text="Schuko" default="" delete_if_empty="true" />
             <space />
             <label text="Authentication:" />
             <checkgroup columns="4">

--- a/resources/data/defaultpresets.xml
+++ b/resources/data/defaultpresets.xml
@@ -2848,7 +2848,9 @@
             <link wiki="Tag:amenity=charging_station" />
             <space />
             <key key="amenity" value="charging_station" />
-            <reference ref="name_ref_operator" />
+            <text key="name" text="Name" />
+            <text key="network" text="Charging Network (MSP)" />
+            <text key="operator" text="Operator (CPO)" />
             <reference ref="oh" />
             <text key="capacity" text="Simultaneously usable charging spots" default="" delete_if_empty="true" />
             <label text="Surroundings and Fees:" />

--- a/resources/data/defaultpresets.xml
+++ b/resources/data/defaultpresets.xml
@@ -2850,12 +2850,16 @@
             <key key="amenity" value="charging_station" />
             <reference ref="name_ref_operator" />
             <reference ref="oh" />
-            <check key="fee" text="Charging fee" default="on" delete_if_empty="true" />
-            <check key="parking:fee" text="Parking fee" default="" delete_if_empty="true" />
+            <text key="capacity" text="Simultaneously usable charging spots" default="" delete_if_empty="true" />
+            <label text="Surroundings and Fees:" />
+            <checkgroup columns="3">
+                <check key="covered" text="Covered" default="" delete_if_empty="true" />
+                <check key="fee" text="Charging fee" default="on" delete_if_empty="true" />
+                <check key="parking:fee" text="Parking fee" default="" delete_if_empty="true" />
+            </checkgroup>
             <space />
             <combo key="voltage" text="Voltage" values="230,400"/>
             <combo key="amperage" text="Amperage" values="16,32" />
-            <combo key="capacity" text="Capacity" values="1,2,3,4,5,6" />
             <space />
             <label text="Types of vehicles which can be charged:" />
             <checkgroup columns="4">

--- a/resources/data/defaultpresets.xml
+++ b/resources/data/defaultpresets.xml
@@ -2853,6 +2853,7 @@
             <text key="operator" text="Operator (CPO)" />
             <reference ref="oh" />
             <text key="capacity" text="Simultaneously usable charging spots" default="" delete_if_empty="true" />
+            <text key="level" text="Floor level, if applicable (ground = 0)" default="" delete_if_empty="true" />
             <label text="Surroundings and Fees:" />
             <checkgroup columns="3">
                 <check key="covered" text="Covered" default="" delete_if_empty="true" />

--- a/resources/data/defaultpresets.xml
+++ b/resources/data/defaultpresets.xml
@@ -2885,15 +2885,13 @@
             <text key="socket:tesla_supercharger:output" text="Tesla Supercharger" default="" delete_if_empty="true" />
             <text key="socket:schuko:output" text="Schuko" default="" delete_if_empty="true" />
             <space />
-            <label text="Authentication:" />
-            <checkgroup columns="4">
-                <check key="authentication:none" text="None" />
-                <check key="authentication:phone_call" text="Phone call" />
-                <check key="authentication:short_message" text="Short message" />
-                <check key="authentication:nfc" text="NFC" />
+            <label text="Unlocking (Authentication):" />
+            <checkgroup columns="3">
+                <check key="authentication:app" text="Unlock through App" />
+                <check key="authentication:contactless" text="Unlock through RFID/NFC" />
+                <check key="authentication:none" text="Usable without registration" />
             </checkgroup>
-            <combo key="authentication:membership_card" text="Membership card" values="yes" />
-            <preset_link preset_name="Payment Methods" />
+            <preset_link preset_name="Payment Methods" text="Edit Payment Methods (only if usable without registration)" />
         </item> <!-- Charging Station -->
         <item name="Wash" icon="presets/vehicle/car_wash.svg" type="node,closedway,multipolygon" preset_name_label="true">
             <link wiki="Tag:amenity=car_wash" />

--- a/resources/data/defaultpresets.xml
+++ b/resources/data/defaultpresets.xml
@@ -2850,7 +2850,8 @@
             <key key="amenity" value="charging_station" />
             <reference ref="name_ref_operator" />
             <reference ref="oh" />
-            <reference ref="fee" />
+            <check key="fee" text="Charging fee" default="on" delete_if_empty="true" />
+            <check key="parking:fee" text="Parking fee" default="" delete_if_empty="true" />
             <space />
             <combo key="voltage" text="Voltage" values="230,400"/>
             <combo key="amperage" text="Amperage" values="16,32" />


### PR DESCRIPTION
Two years ago, the Swiss OSM community organized the "[Project of the Month: Charging Stations](https://wiki.openstreetmap.org/wiki/DE:Project_of_the_month_Switzerland/Charging_Stations)". For this mapping project, I created a custom preset for mapping Swiss EV charging stations: https://github.com/dbrgn/josm-presets I'm an EV driver myself, and I mapped probably hundreds of charging stations in Switzerland and other European countries.

That preset is quite specific to the Swiss market, so it's not applicable to all countries. However, based on the things we learned from the preset being used by a few people over that month, we can make a lot of improvements to the current JOSM default preset for charging stations.

The commits of this PR are nicely separated and commented, so that if one of the changes is controversial, it could be removed. However, I can also squash the commits if that is preferred.

The biggest change is the commit that changes the approach for mapping charging sockets. Here's the commit description:

> First of all, I changed the input type from "combo" to "text". There are charging stations with a dozen or more charging spots, so having fixed numbers 1-6 doesn't make sense.
> 
> Next, I looked at how common these sockets are. Here is the list based on taginfo:
> 
> More than 1000: type2 (40204), type2_combo (13356), chademo (10754), schuko (6178), type2_cable (5397), type1 (3174), tesla_supercharger (1295)
> 
> Less than 1000: type3 (761), type1_combo (664), cee_blue (413), sev1011_t23 (202), cee_red_16a (180), cee_red_32a (119), nema_5_15 (98), nema_5_20 (46), sev1011_t13 (38)
> 
> Based on this research, I removed all entries that had less than 1000 occurrences. The affected sockets are either slow household-type sockets, or old standards that are being replaced with newer standards (type1_combo, type3).
> 
> Schuko is a bit special. It's slow and I assume most usages are for bicycle charging stations. However, an overpass query in europe for nodes tagged with Schuko in combination with both "amenity=charging_station" and "motorcar=yes" still turned up over 1700 entries, so I decided to leave it in the list for now.
> 
> One entry that was previously missing is "type2_cable". The distinction between just the socket and a cable is important for people that don't have their own charging cable, and for people that want to charge type1 cars using an adapter.

Reducing the number of sockets (by removing obscure socket types) gives us enough screen space to also map the output power per socket.

Screenshot before and after:

![image](https://github.com/JOSM/josm/assets/105168/7b10143d-8202-4d1d-9380-777c5164ddc2)
