### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/test/unit/org/openstreetmap/josm/JOSMFixture.java
+++ b/test/unit/org/openstreetmap/josm/JOSMFixture.java
@@ -154,8 +154,8 @@ public class JOSMFixture {
     }
 
     private static boolean isProductionApiUrl(String url) {
-        return url.startsWith("http://www.openstreetmap.org") || url.startsWith("http://api.openstreetmap.org")
-            || url.startsWith("https://www.openstreetmap.org") || url.startsWith("https://api.openstreetmap.org");
+        return url.startsWith("http://api.openstreetmap.org")
+            || url.startsWith("https://api.openstreetmap.org");
     }
 
     private void setupGUI() {

--- a/test/unit/org/openstreetmap/josm/actions/downloadtasks/DownloadGpsTaskTest.java
+++ b/test/unit/org/openstreetmap/josm/actions/downloadtasks/DownloadGpsTaskTest.java
@@ -25,14 +25,14 @@ class DownloadGpsTaskTest extends AbstractDownloadTaskTestParent {
         DownloadGpsTask task = new DownloadGpsTask();
         assertFalse(task.acceptsUrl(null));
         assertFalse(task.acceptsUrl(""));
-        assertTrue(task.acceptsUrl("http://api.openstreetmap.org/api/0.6/trackpoints?bbox=0,51.5,0.25,51.75"));
-        assertTrue(task.acceptsUrl("http://api.openstreetmap.org/api/0.6/trackpoints?bbox=0,51.5,0.25,51.75&page=0"));
-        assertTrue(task.acceptsUrl("http://api.openstreetmap.org/trace/5000/data"));
-        assertTrue(task.acceptsUrl("http://www.openstreetmap.org/trace/5000/data"));
+        assertTrue(task.acceptsUrl("https://api.openstreetmap.org/api/0.6/trackpoints?bbox=0,51.5,0.25,51.75"));
+        assertTrue(task.acceptsUrl("https://api.openstreetmap.org/api/0.6/trackpoints?bbox=0,51.5,0.25,51.75&page=0"));
+        assertTrue(task.acceptsUrl("https://api.openstreetmap.org/trace/5000/data"));
+        assertTrue(task.acceptsUrl("https://www.openstreetmap.org/trace/5000/data"));
         assertTrue(task.acceptsUrl("http://www.trackmyjourney.co.uk/exportgpx.php?session=S6rZR2Bh6GwX1wpB0C&trk=79292"));
         assertTrue(task.acceptsUrl("https://www.openstreetmap.org/user/simon04/traces/750057"));
         assertTrue(task.acceptsUrl("https://www.openstreetmap.org/edit?gpx=750057"));
-        assertTrue(task.acceptsUrl("http://www.openstreetmap.org/edit?gpx=2277313#map=14/-20.7321/-40.5328"));
+        assertTrue(task.acceptsUrl("https://www.openstreetmap.org/edit?gpx=2277313#map=14/-20.7321/-40.5328"));
         assertTrue(task.acceptsUrl("https://tasks.hotosm.org/api/v1/project/4019/tasks_as_gpx?tasks=125&as_file=true"));
         assertTrue(task.acceptsUrl(getRemoteFileUrl()));
     }

--- a/test/unit/org/openstreetmap/josm/actions/downloadtasks/DownloadNotesTaskTest.java
+++ b/test/unit/org/openstreetmap/josm/actions/downloadtasks/DownloadNotesTaskTest.java
@@ -25,10 +25,10 @@ class DownloadNotesTaskTest extends AbstractDownloadTaskTestParent {
         DownloadNotesTask task = new DownloadNotesTask();
         assertFalse(task.acceptsUrl(null));
         assertFalse(task.acceptsUrl(""));
-        assertTrue(task.acceptsUrl("http://api.openstreetmap.org/api/0.6/notes?bbox=-0.65094,51.312159,0.374908,51.669148"));
-        assertTrue(task.acceptsUrl("http://api.openstreetmap.org/api/0.6/notes.json?bbox=-0.65094,51.312159,0.374908,51.669148"));
-        assertTrue(task.acceptsUrl("http://api.openstreetmap.org/api/0.6/notes.xml?bbox=-0.65094,51.312159,0.374908,51.669148"));
-        assertTrue(task.acceptsUrl("http://api.openstreetmap.org/api/0.6/notes.gpx?bbox=-0.65094,51.312159,0.374908,51.669148"));
+        assertTrue(task.acceptsUrl("https://api.openstreetmap.org/api/0.6/notes?bbox=-0.65094,51.312159,0.374908,51.669148"));
+        assertTrue(task.acceptsUrl("https://api.openstreetmap.org/api/0.6/notes.json?bbox=-0.65094,51.312159,0.374908,51.669148"));
+        assertTrue(task.acceptsUrl("https://api.openstreetmap.org/api/0.6/notes.xml?bbox=-0.65094,51.312159,0.374908,51.669148"));
+        assertTrue(task.acceptsUrl("https://api.openstreetmap.org/api/0.6/notes.gpx?bbox=-0.65094,51.312159,0.374908,51.669148"));
         assertTrue(task.acceptsUrl(getRemoteFileUrl()));
     }
 

--- a/test/unit/org/openstreetmap/josm/actions/downloadtasks/DownloadOsmTaskTest.java
+++ b/test/unit/org/openstreetmap/josm/actions/downloadtasks/DownloadOsmTaskTest.java
@@ -25,12 +25,12 @@ class DownloadOsmTaskTest extends AbstractDownloadTaskTestParent {
         DownloadOsmTask task = new DownloadOsmTask();
         assertFalse(task.acceptsUrl(null));
         assertFalse(task.acceptsUrl(""));
-        assertTrue(task.acceptsUrl("http://api.openstreetmap.org/api/0.6/node/100"));
-        assertTrue(task.acceptsUrl("http://api.openstreetmap.org/api/0.6/way/100"));
-        assertTrue(task.acceptsUrl("http://api.openstreetmap.org/api/0.6/relation/100"));
-        assertTrue(task.acceptsUrl("http://api.openstreetmap.org/api/0.6/nodes?nodes=101,102,103"));
-        assertTrue(task.acceptsUrl("http://api.openstreetmap.org/api/0.6/ways?ways=101,102,103"));
-        assertTrue(task.acceptsUrl("http://api.openstreetmap.org/api/0.6/relations?relations=101,102,103"));
+        assertTrue(task.acceptsUrl("https://api.openstreetmap.org/api/0.6/node/100"));
+        assertTrue(task.acceptsUrl("https://api.openstreetmap.org/api/0.6/way/100"));
+        assertTrue(task.acceptsUrl("https://api.openstreetmap.org/api/0.6/relation/100"));
+        assertTrue(task.acceptsUrl("https://api.openstreetmap.org/api/0.6/nodes?nodes=101,102,103"));
+        assertTrue(task.acceptsUrl("https://api.openstreetmap.org/api/0.6/ways?ways=101,102,103"));
+        assertTrue(task.acceptsUrl("https://api.openstreetmap.org/api/0.6/relations?relations=101,102,103"));
         assertTrue(task.acceptsUrl(getRemoteFileUrl()));
     }
 

--- a/test/unit/org/openstreetmap/josm/data/UserIdentityManagerTest.java
+++ b/test/unit/org/openstreetmap/josm/data/UserIdentityManagerTest.java
@@ -184,10 +184,10 @@ class UserIdentityManagerTest {
             new String[] {"osm-server.url", null, "osm-server.username", null},
             "Preferences include neither an url nor a user name => we have an anonymous user"),
           Arguments.of((Function<UserIdentityManager, Boolean>) UserIdentityManager::isAnonymous,
-            new String[] {"osm-server.url", "http://api.openstreetmap.org", "osm-server.username", null},
+            new String[] {"osm-server.url", "https://api.openstreetmap.org", "osm-server.username", null},
             "Preferences include neither an url nor a user name => we have an anonymous user"),
           Arguments.of((Function<UserIdentityManager, Boolean>) UserIdentityManager::isPartiallyIdentified,
-            new String[] {"osm-server.url", "http://api.openstreetmap.org", "osm-server.username", "test"},
+            new String[] {"osm-server.url", "https://api.openstreetmap.org", "osm-server.username", "test"},
             "Preferences include an user name => we have a partially identified user")
         );
     }
@@ -236,7 +236,7 @@ class UserIdentityManagerTest {
         try {
             im.setFullyIdentified("test1", newUserInfo());
 
-            Config.getPref().put("osm-server.url", "http://api.openstreetmap.org");
+            Config.getPref().put("osm-server.url", "https://api.openstreetmap.org");
             Config.getPref().put("osm-server.username", "test2");
 
             im.initFromPreferences();
@@ -262,7 +262,7 @@ class UserIdentityManagerTest {
         try {
             im.setFullyIdentified("test1", new UserInfo());
 
-            Config.getPref().put("osm-server.url", "http://api.openstreetmap.org");
+            Config.getPref().put("osm-server.url", "https://api.openstreetmap.org");
             Config.getPref().put("osm-server.username", "test1");
 
             im.initFromPreferences();
@@ -280,7 +280,7 @@ class UserIdentityManagerTest {
         // reset it
         im.setAnonymous();
 
-        Config.getPref().put("osm-server.url", "http://api.openstreetmap.org");
+        Config.getPref().put("osm-server.url", "https://api.openstreetmap.org");
         assertTrue(im.isAnonymous());
 
         Config.getPref().put("osm-server.url", null);
@@ -289,7 +289,7 @@ class UserIdentityManagerTest {
         // reset it
         im.setPartiallyIdentified("test");
 
-        Config.getPref().put("osm-server.url", "http://api.openstreetmap.org");
+        Config.getPref().put("osm-server.url", "https://api.openstreetmap.org");
         assertTrue(im.isPartiallyIdentified());
         assertEquals("test", im.getUserName());
 
@@ -299,7 +299,7 @@ class UserIdentityManagerTest {
         // reset it
         im.setFullyIdentified("test", newUserInfo());
 
-        Config.getPref().put("osm-server.url", "http://api.openstreetmap.org");
+        Config.getPref().put("osm-server.url", "https://api.openstreetmap.org");
         assertTrue(im.isPartiallyIdentified());
         assertEquals("test", im.getUserName());
 

--- a/test/unit/org/openstreetmap/josm/data/notes/NoteTest.java
+++ b/test/unit/org/openstreetmap/josm/data/notes/NoteTest.java
@@ -67,8 +67,8 @@ class NoteTest {
                 "<osm version=\"0.6\" generator=\"OpenStreetMap server\">\n" +
                 "<note lon=\"68.86415\" lat=\"36.7232991\">\n"+
                 "  <id>4</id>\n"+
-                "  <url>http://api.openstreetmap.org/api/0.6/notes/4</url>\n"+
-                "  <reopen_url>http://api.openstreetmap.org/api/0.6/notes/4/reopen</reopen_url>\n"+
+                "  <url>https://api.openstreetmap.org/api/0.6/notes/4</url>\n"+
+                "  <reopen_url>https://api.openstreetmap.org/api/0.6/notes/4/reopen</reopen_url>\n"+
                 "  <date_created>2013-04-24 08:07:02 UTC</date_created>\n"+
                 "  <status>closed</status>\n"+
                 "  <date_closed>2013-04-24 08:08:51 UTC</date_closed>\n"+
@@ -77,7 +77,7 @@ class NoteTest {
                 "      <date>2013-04-24 08:07:02 UTC</date>\n"+
                 "      <uid>1626</uid>\n"+
                 "      <user>FredB</user>\n"+
-                "      <user_url>http://www.openstreetmap.org/user/FredB</user_url>\n"+
+                "      <user_url>https://www.openstreetmap.org/user/FredB</user_url>\n"+
                 "      <action>opened</action>\n"+
                 "      <text>test</text>\n"+
                 "      <html>&lt;p&gt;test&lt;/p&gt;</html>\n"+
@@ -86,7 +86,7 @@ class NoteTest {
                 "      <date>2013-04-24 08:08:51 UTC</date>\n"+
                 "      <uid>1626</uid>\n"+
                 "      <user>FredB</user>\n"+
-                "      <user_url>http://www.openstreetmap.org/user/FredB</user_url>\n"+
+                "      <user_url>https://www.openstreetmap.org/user/FredB</user_url>\n"+
                 "      <action>closed</action>\n"+
                 "      <text></text>\n"+
                 "      <html>&lt;p&gt;&lt;/p&gt;</html>\n"+
@@ -95,9 +95,9 @@ class NoteTest {
                 "</note>\n"+
                 "<note lon=\"23.2663071\" lat=\"50.7173607\">\n" +
                 "  <id>1396945</id>\n" +
-                "  <url>https://www.openstreetmap.org/api/0.6/notes/1396945</url>\n" +
-                "  <comment_url>https://www.openstreetmap.org/api/0.6/notes/1396945/comment</comment_url>\n" +
-                "  <close_url>https://www.openstreetmap.org/api/0.6/notes/1396945/close</close_url>\n" +
+                "  <url>https://api.openstreetmap.org/api/0.6/notes/1396945</url>\n" +
+                "  <comment_url>https://api.openstreetmap.org/api/0.6/notes/1396945/comment</comment_url>\n" +
+                "  <close_url>https://api.openstreetmap.org/api/0.6/notes/1396945/close</close_url>\n" +
                 "  <date_created>2018-05-17 15:41:06 UTC</date_created>\n" +
                 "  <status>open</status>\n" +
                 "  <comments>\n" +

--- a/test/unit/org/openstreetmap/josm/io/NoteReaderTest.java
+++ b/test/unit/org/openstreetmap/josm/io/NoteReaderTest.java
@@ -33,8 +33,8 @@ class NoteReaderTest {
             "<osm version=\"0.6\" generator=\"OpenStreetMap server\">\n"+
             "<note lon=\"68.86415\" lat=\"36.7232991\">\n"+
             "  <id>4</id>\n"+
-            "  <url>http://api.openstreetmap.org/api/0.6/notes/4</url>\n"+
-            "  <reopen_url>http://api.openstreetmap.org/api/0.6/notes/4/reopen</reopen_url>\n"+
+            "  <url>https://api.openstreetmap.org/api/0.6/notes/4</url>\n"+
+            "  <reopen_url>https://api.openstreetmap.org/api/0.6/notes/4/reopen</reopen_url>\n"+
             "  <date_created>2013-04-24 08:07:02 UTC</date_created>\n"+
             "  <status>closed</status>\n"+
             "  <date_closed>2013-04-24 08:08:51 UTC</date_closed>\n"+
@@ -43,7 +43,7 @@ class NoteReaderTest {
             "      <date>2013-04-24 08:07:02 UTC</date>\n"+
             "      <uid>1626</uid>\n"+
             "      <user>FredB</user>\n"+
-            "      <user_url>http://www.openstreetmap.org/user/FredB</user_url>\n"+
+            "      <user_url>https://www.openstreetmap.org/user/FredB</user_url>\n"+
             "      <action>opened</action>\n"+
             "      <text>test</text>\n"+
             "      <html>&lt;p&gt;test&lt;/p&gt;</html>\n"+
@@ -52,7 +52,7 @@ class NoteReaderTest {
             "      <date>2013-04-24 08:08:51 UTC</date>\n"+
             "      <uid>1626</uid>\n"+
             "      <user>FredB</user>\n"+
-            "      <user_url>http://www.openstreetmap.org/user/FredB</user_url>\n"+
+            "      <user_url>https://www.openstreetmap.org/user/FredB</user_url>\n"+
             "      <action>closed</action>\n"+
             "      <text></text>\n"+
             "      <html>&lt;p&gt;&lt;/p&gt;</html>\n"+

--- a/test/unit/org/openstreetmap/josm/io/OsmChangesetParserTest.java
+++ b/test/unit/org/openstreetmap/josm/io/OsmChangesetParserTest.java
@@ -21,7 +21,7 @@ class OsmChangesetParserTest {
 
     private static final String BEGIN =
         "<osm version=\"0.6\" generator=\"OpenStreetMap server\" copyright=\"OpenStreetMap and contributors\" " +
-                "attribution=\"http://www.openstreetmap.org/copyright\" license=\"http://opendatacommons.org/licenses/odbl/1-0/\">" +
+                "attribution=\"https://www.openstreetmap.org/copyright\" license=\"https://opendatacommons.org/licenses/odbl/1-0/\">" +
             "<changeset id=\"36749147\" user=\"kesler\" uid=\"13908\" created_at=\"2016-01-22T21:55:37Z\" "+
                 "closed_at=\"2016-01-22T21:56:39Z\"  open=\"false\" min_lat=\"36.6649211\" min_lon=\"55.377015\" max_lat=\"38.1490357\" " +
                 "max_lon=\"60.3766983\" comments_count=\"2\" changes_count=\"9\">" +
@@ -33,7 +33,7 @@ class OsmChangesetParserTest {
         "<comment date=\"2016-09-13T13:28:20Z\" uid=\"1733149\" user=\"Jean Passepartout\">" +
             "<text>" +
                 "Hi keeler, Thank you for contributing to OpenStreetMap. " +
-                "I noticed you added this way: http://www.openstreetmap.org/way/363580576, " +
+                "I noticed you added this way: https://www.openstreetmap.org/way/363580576, " +
                 "but it is a duplicate of another way, with a different name. "+
                 "Could you review and fix this? Please let me know if you need any help. " +
                 "Thank you and Happy Mapping! Jean Passepartout" +
@@ -62,7 +62,7 @@ class OsmChangesetParserTest {
      */
     @Test
     void testParseWithoutDiscussion() throws IllegalDataException {
-        // http://api.openstreetmap.org/api/0.6/changeset/36749147
+        // https://api.openstreetmap.org/api/0.6/changeset/36749147
         Changeset cs = parse(BEGIN + END).iterator().next();
         assertEquals(2, cs.getCommentsCount());
         assertEquals(9, cs.getChangesCount());
@@ -75,7 +75,7 @@ class OsmChangesetParserTest {
      */
     @Test
     void testParseWithDiscussion() throws IllegalDataException {
-        // http://api.openstreetmap.org/api/0.6/changeset/36749147?include_discussion=true
+        // https://api.openstreetmap.org/api/0.6/changeset/36749147?include_discussion=true
         Changeset cs = parse(BEGIN + DISCUSSION + END).iterator().next();
         assertEquals(2, cs.getCommentsCount());
         assertEquals(9, cs.getChangesCount());

--- a/test/unit/org/openstreetmap/josm/io/OsmJsonReaderTest.java
+++ b/test/unit/org/openstreetmap/josm/io/OsmJsonReaderTest.java
@@ -66,7 +66,7 @@ class OsmJsonReaderTest {
                 "    \"copyright\": \"The data included in this document is from www.openstreetmap.org. " +
                                      "It has there been collected by a large group of contributors. " +
                                      "For individual attribution of each item please refer to " +
-                                     "http://www.openstreetmap.org/api/0.6/[node|way|relation]/#id/history\"\n" +
+                                     "https://api.openstreetmap.org/api/0.6/[node|way|relation]/#id/history\"\n" +
                 "  },\n" +
                 "  \"elements\": [" + osm + "]\n" +
                 extraContent +


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)

Except in validating a (manual) url, where the HTTP version has been left as valid for now.
Optionally, warn users if they are using the `www` and/or HTTP url.

Also changes some other URLs which redirect from HTTP to HTTPS into HTTPS urls.

This GitHub PR does not have a linked JOSM issue ticket at https://josm.openstreetmap.de/report .
Commit descriptions are left as default 'updated file ...'.

cc: @tsmock