### PR TITLE
Issue 23943 - allow negative indices in substring to remove from the end of the string

### DIFF
--- a/src/org/openstreetmap/josm/gui/mappaint/mapcss/Functions.java
+++ b/src/org/openstreetmap/josm/gui/mappaint/mapcss/Functions.java
@@ -1034,12 +1034,12 @@ public final class Functions {
      * and ending at index {@code end}, (exclusive, 0-indexed).
      * @param s The base string
      * @param begin The start index
-     * @param end The end index
+     * @param end The end index. If negative, it counts from the end of the string
      * @return the substring
      * @see String#substring(int, int)
      */
     public static String substring(String s, float begin, float end) {
-        return s == null ? null : s.substring((int) begin, (int) end);
+        return s == null ? null : s.substring((int) begin, (int) (end >= 0 ? end : s.length() + end));
     }
 
     /**


### PR DESCRIPTION
https://josm.openstreetmap.de/ticket/23943

Summarized, see ticket for details:
- Current behavior: StringIndexOutOfBoundsException
- Current methods to remove a fixed number of characters from the end of the string: ugly workarounds are necessary to obtain the desired behavior (unless the length of the string is already known beforehand, in which a hardcoded index can be used)
- Proposed method: allow negative end indices to remove characters from the end of the string