### PR TITLE
Update SearchDialog.java to show hint for key is null

### DIFF
--- a/src/org/openstreetmap/josm/gui/dialogs/SearchDialog.java
+++ b/src/org/openstreetmap/josm/gui/dialogs/SearchDialog.java
@@ -325,7 +325,7 @@ public class SearchDialog extends ExtendedDialog {
                 .addKeyword("<i>key</i>=<i>value</i>", null, tr("''key'' with exactly ''value''"))
                 .addKeyword("<i>key</i>~<i>regexp</i>", null, tr("value of ''key'' matching the regular expression ''regexp''"))
                 .addKeyword("<i>key</i>=*", null, tr("''key'' with any value"))
-                .addKeyword("<i>key</i>=", null, tr("''key'' with empty value"))
+                .addKeyword("<i>key</i> is null", null, tr("matches if ''key'' does not exist"))
                 .addKeyword("*=<i>value</i>", null, tr("''value'' in any key"))
                 .addKeyword("<i>key</i>><i>value</i>", null, tr("matches if ''key'' is greater than ''value'' (analogously, less than)"))
                 .addKeyword("\"key\"=\"value\"", "\"\"=\"\"",


### PR DESCRIPTION
The current example of "key=" is not working for me for me and don't make a lot of sense. can a key even exist without a value? A more common scenario is searching for objects missing a key, which I've changed this hint to.