### PR TITLE
Accept 'expressway' as valid maxspeed source

### DIFF
--- a/src/org/openstreetmap/josm/data/validation/tests/Highways.java
+++ b/src/org/openstreetmap/josm/data/validation/tests/Highways.java
@@ -60,7 +60,7 @@ public class Highways extends Test {
 
     private static final Set<String> KNOWN_SOURCE_MAXSPEED_CONTEXTS = new HashSet<>(Arrays.asList(
             "urban", "rural", "zone", "zone10", "zone:10", "zone20", "zone:20", "zone30", "zone:30", "zone40", "zone:40", "zone60", "zone:60",
-            "nsl_single", "nsl_dual", "motorway", "trunk", "living_street", "bicycle_road"));
+            "nsl_single", "nsl_dual", "motorway", "trunk", "living_street", "bicycle_road", "expressway"));
 
     private static final Set<String> ISO_COUNTRIES = new HashSet<>(Arrays.asList(Locale.getISOCountries()));
 


### PR DESCRIPTION
In Poland it was agreed to use `PL:expressway` as `source:maxspeed` value for S-class roads.

https://taginfo.geofabrik.de/europe:poland/tags/source%3Amaxspeed=PL%3Aexpressway
https://www.openstreetmap.org/changeset/159759046
https://github.com/Project-OSRM/osrm-backend/pull/7079
