### PR TITLE
Use `VolatileImage` for back-buffers to allow hardware-accelerated rendering

### DIFF
--- a/src/org/openstreetmap/josm/gui/MapView.java
+++ b/src/org/openstreetmap/josm/gui/MapView.java
@@ -7,7 +7,6 @@ import java.awt.AWTException;
 import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -333,22 +332,24 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
         return Arrays.asList(zoomSlider, scaler);
     }
 
-    private static VolatileImage getAcceleratedImage(Component mv, int width, int height) {
+    private VolatileImage getAcceleratedBuffer() {
         VolatileImage volatileImage;
+        var width = getWidth();
+        var height = getHeight();
         // Creating a VolatileImage is impossible if 1) we’re headless or 2) our component is isolated (i.e., not in a
         // container). The former is inherent to VolatileImage creation; the latter is not, so we need to check that to
         // produce optimal VolatileImages.
-        if (null != mv.getGraphicsConfiguration()) {
+        if (null != getGraphicsConfiguration()) {
             // TODO: allow user to toggle between SW-backed and HW-backed?
             var volatileImageCapabilities = new ImageCapabilities(true);
             try {
-                volatileImage = mv.getGraphicsConfiguration().createCompatibleVolatileImage(width, height, volatileImageCapabilities, Transparency.OPAQUE);
+                volatileImage = getGraphicsConfiguration().createCompatibleVolatileImage(width, height, volatileImageCapabilities, Transparency.OPAQUE);
             } catch (AWTException e) {
                 //
-                volatileImage = mv.getGraphicsConfiguration().createCompatibleVolatileImage(width, height, Transparency.OPAQUE);
+                volatileImage = getGraphicsConfiguration().createCompatibleVolatileImage(width, height, Transparency.OPAQUE);
             }
         } else {
-            volatileImage = mv.createVolatileImage(width, height);
+            volatileImage = createVolatileImage(width, height);
         }
         if (null != volatileImage) {
             volatileImage.setAccelerationPriority(1);
@@ -538,7 +539,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
                     || VolatileImage.IMAGE_INCOMPATIBLE == offscreenBuffer.validate(getGraphicsConfiguration())
                     || offscreenBuffer.getWidth() != getWidth()
                     || offscreenBuffer.getHeight() != getHeight()) {
-                offscreenBuffer = getAcceleratedImage(this, getWidth(), getHeight());
+                offscreenBuffer = getAcceleratedBuffer();
             }
             var g2 = offscreenBuffer.createGraphics();
             g2.setClip(g.getClip());
@@ -589,7 +590,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
         do {
             if (null == unchangedLayersBuffer
                     || VolatileImage.IMAGE_INCOMPATIBLE == unchangedLayersBuffer.validate(getGraphicsConfiguration())) {
-                unchangedLayersBuffer = getAcceleratedImage(this, getWidth(), getHeight());
+                unchangedLayersBuffer = getAcceleratedBuffer();
                 canUseBuffer = false;
             }
             if (!canUseBuffer || (unchangedLayers.size() != nonChangedLayersCount)) {

--- a/src/org/openstreetmap/josm/gui/MapView.java
+++ b/src/org/openstreetmap/josm/gui/MapView.java
@@ -85,12 +85,12 @@ import org.openstreetmap.josm.tools.Utils;
 import org.openstreetmap.josm.tools.bugreport.BugReport;
 
 /**
- * This is a component used in the {@link MapFrame} for browsing the map. It use is to
+ * This is a component used in the {@link MapFrame} for browsing the map. It’s used to
  * provide the MapMode's enough capabilities to operate.<br><br>
  *
  * {@code MapView} holds meta-data about the data set currently displayed, as scale level,
  * center point viewed, what scrolling mode or editing mode is selected or with
- * what projection the map is viewed etc..<br><br>
+ * what projection the map is viewed, etc.<br><br>
  *
  * {@code MapView} is able to administrate several layers.
  *
@@ -356,7 +356,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
         return volatileImage;
     }
 
-    // remebered geometry of the component
+    // Remembered geometry of the component
     private Dimension oldSize;
     private Point oldLoc;
 
@@ -455,7 +455,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
 
     /**
      * Checks if virtual nodes should be drawn. Default is <code>false</code>
-     * @return The virtual nodes property.
+     * @return The virtual node’s property.
      * @see Rendering#render
      */
     public boolean isVirtualNodesEnabled() {
@@ -625,7 +625,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
                         paintLayer(layer, g2);
                     }
                 } else {
-                    // Maybe there were more unchanged layers then last time - draw them to buffer
+                    // If there were more unchanged layers than last time, draw them to the buffer
                     for (var layer : visibleLayers.subList(unchangedLayers.size(), nonChangedLayersCount)) {
                         paintLayer(layer, g2);
                     }

--- a/src/org/openstreetmap/josm/gui/MapView.java
+++ b/src/org/openstreetmap/josm/gui/MapView.java
@@ -602,7 +602,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
         } while (offscreenBuffer.contentsLost());
     }
 
-    private int renderUnchangedLayersBuffer(Graphics2D g, List<Layer> visibleLayers, int nonChangedLayersCount) {
+    private void renderUnchangedLayersBuffer(Graphics2D g, List<Layer> visibleLayers, int nonChangedLayersCount) {
         boolean canUseBuffer = !paintPreferencesChanged.getAndSet(false)
                 && unchangedLayers.size() <= nonChangedLayersCount
                 && lastViewID == getViewID()
@@ -637,7 +637,6 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
         unchangedLayers.addAll(visibleLayers.subList(0, nonChangedLayersCount));
         lastViewID = getViewID();
         lastClipBounds = g.getClipBounds();
-        return nonChangedLayersCount;
     }
 
     private int getUnchangedLayersCount(List<Layer> visibleLayers) {

--- a/src/org/openstreetmap/josm/gui/MapView.java
+++ b/src/org/openstreetmap/josm/gui/MapView.java
@@ -616,7 +616,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
                         || VolatileImage.IMAGE_INCOMPATIBLE == unchangedLayersBuffer.validate(getGraphicsConfiguration())) {
                     unchangedLayersBuffer = getAcceleratedImage(this, getWidth(), getHeight());
                 }
-                Graphics2D g2 = unchangedLayersBuffer.createGraphics();
+                var g2 = unchangedLayersBuffer.createGraphics();
                 g2.setClip(g.getClip());
                 if (!canUseBuffer) {
                     g2.setColor(PaintColors.getBackgroundColor());

--- a/src/org/openstreetmap/josm/gui/MapView.java
+++ b/src/org/openstreetmap/josm/gui/MapView.java
@@ -575,6 +575,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
             for (int i = 0; i < nonChangedLayersCount; i++) {
                 paintLayer(visibleLayers.get(i), g2);
             }
+            g2.dispose();
         } else {
             // Maybe there were more unchanged layers then last time - draw them to buffer
             if (nonChangedLayers.size() != nonChangedLayersCount) {
@@ -584,6 +585,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
                 for (int i = nonChangedLayers.size(); i < nonChangedLayersCount; i++) {
                     paintLayer(visibleLayers.get(i), g2);
                 }
+                g2.dispose();
             }
         }
 
@@ -628,6 +630,8 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
         if (playHeadMarker != null) {
             playHeadMarker.paint(tempG, this);
         }
+
+        tempG.dispose();
 
         try {
             g.setTransform(new AffineTransform(1, 0, 0, 1, trOrig.getTranslateX(), trOrig.getTranslateY()));

--- a/src/org/openstreetmap/josm/gui/MapView.java
+++ b/src/org/openstreetmap/josm/gui/MapView.java
@@ -604,9 +604,9 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
 
     private void renderUnchangedLayersBuffer(Graphics2D g, List<Layer> visibleLayers, int nonChangedLayersCount) {
         boolean canUseBuffer = !paintPreferencesChanged.getAndSet(false)
-                && unchangedLayers.size() <= nonChangedLayersCount
                 && lastViewID == getViewID()
                 && lastClipBounds.contains(g.getClipBounds())
+                && unchangedLayers.size() <= nonChangedLayersCount
                 && unchangedLayers.equals(visibleLayers.subList(0, unchangedLayers.size()));
         if (!canUseBuffer || unchangedLayers.size() != nonChangedLayersCount) {
             do {

--- a/src/org/openstreetmap/josm/gui/MapView.java
+++ b/src/org/openstreetmap/josm/gui/MapView.java
@@ -234,8 +234,8 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
      */
     private final transient Set<MapViewPaintable> temporaryLayers = new LinkedHashSet<>();
 
-    private transient BufferedImage nonChangedLayersBuffer;
-    private transient BufferedImage offscreenBuffer;
+    private transient BufferedImage nonChangedLayersBuffer = getAcceleratedImage(MapView.this, 1, 1);
+    private transient BufferedImage offscreenBuffer = getAcceleratedImage(MapView.this, 1, 1);
     // Layers that wasn't changed since last paint
     private final transient List<Layer> nonChangedLayers = new ArrayList<>();
     private int lastViewID;
@@ -335,7 +335,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
     }
 
     private static BufferedImage getAcceleratedImage(Component mv, int width, int height) {
-        if (GraphicsEnvironment.isHeadless()) {
+        if (GraphicsEnvironment.isHeadless() || null == mv.getGraphicsConfiguration()) {
             return new BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR);
         }
         return mv.getGraphicsConfiguration().createCompatibleImage(width, height, Transparency.OPAQUE);
@@ -558,13 +558,12 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
                 && lastClipBounds.contains(g.getClipBounds())
                 && nonChangedLayers.equals(visibleLayers.subList(0, nonChangedLayers.size()));
 
-        if (null == offscreenBuffer || offscreenBuffer.getWidth() != width || offscreenBuffer.getHeight() != height) {
+        if (offscreenBuffer.getWidth() != width || offscreenBuffer.getHeight() != height) {
             offscreenBuffer = getAcceleratedImage(this, width, height);
         }
 
-        if (!canUseBuffer || nonChangedLayersBuffer == null) {
-            if (null == nonChangedLayersBuffer
-                    || nonChangedLayersBuffer.getWidth() != width || nonChangedLayersBuffer.getHeight() != height) {
+        if (!canUseBuffer) {
+            if (nonChangedLayersBuffer.getWidth() != width || nonChangedLayersBuffer.getHeight() != height) {
                 nonChangedLayersBuffer = getAcceleratedImage(this, width, height);
             }
             Graphics2D g2 = nonChangedLayersBuffer.createGraphics();

--- a/src/org/openstreetmap/josm/gui/MapView.java
+++ b/src/org/openstreetmap/josm/gui/MapView.java
@@ -608,7 +608,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
                 && lastViewID == getViewID()
                 && lastClipBounds.contains(g.getClipBounds())
                 && unchangedLayers.equals(visibleLayers.subList(0, unchangedLayers.size()));
-        if (!canUseBuffer || (canUseBuffer && unchangedLayers.size() != nonChangedLayersCount)) {
+        if (!canUseBuffer || unchangedLayers.size() != nonChangedLayersCount) {
             do {
                 if (null == unchangedLayersBuffer
                         || unchangedLayersBuffer.getWidth() != getWidth()

--- a/src/org/openstreetmap/josm/gui/MapView.java
+++ b/src/org/openstreetmap/josm/gui/MapView.java
@@ -311,6 +311,7 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
             AutoFilterManager.getInstance().enableAutoFilterRule(AutoFilterManager.PROP_AUTO_FILTER_RULE.get());
         }
         setTransferHandler(new OsmTransferHandler());
+        setOpaque(true);
     }
 
     /**

--- a/src/org/openstreetmap/josm/gui/MapView.java
+++ b/src/org/openstreetmap/josm/gui/MapView.java
@@ -569,8 +569,8 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
                 g2.drawImage(unchangedLayersBuffer, 0, 0, null);
             } while (unchangedLayersBuffer.contentsLost());
 
-            for (int i = unchangedLayersCount; i < visibleLayers.size(); i++) {
-                paintLayer(visibleLayers.get(i), g2);
+            for (var layer : visibleLayers.subList(unchangedLayersCount, visibleLayers.size())) {
+                paintLayer(layer, g2);
             }
 
             try {
@@ -621,13 +621,13 @@ LayerManager.LayerChangeListener, MainLayerManager.ActiveLayerChangeListener {
                 if (!canUseBuffer) {
                     g2.setColor(PaintColors.getBackgroundColor());
                     g2.fillRect(0, 0, getWidth(), getHeight());
-                    for (int i = 0; i < nonChangedLayersCount; i++) {
-                        paintLayer(visibleLayers.get(i), g2);
+                    for (var layer : visibleLayers.subList(0, nonChangedLayersCount)) {
+                        paintLayer(layer, g2);
                     }
                 } else {
                     // Maybe there were more unchanged layers then last time - draw them to buffer
-                    for (int i = unchangedLayers.size(); i < nonChangedLayersCount; i++) {
-                        paintLayer(visibleLayers.get(i), g2);
+                    for (var layer : visibleLayers.subList(unchangedLayers.size(), nonChangedLayersCount)) {
+                        paintLayer(layer, g2);
                     }
                 }
                 g2.dispose();

--- a/src/org/openstreetmap/josm/gui/layer/OsmDataLayer.java
+++ b/src/org/openstreetmap/josm/gui/layer/OsmDataLayer.java
@@ -1507,12 +1507,14 @@ public class OsmDataLayer extends AbstractOsmDataLayer
 
     @Override
     public void primitiveHovered(PrimitiveHoverEvent e) {
-        List<IPrimitive> primitives = new ArrayList<>(2);
-        primitives.add(e.getHoveredPrimitive());
-        primitives.add(e.getPreviousPrimitive());
-        primitives.removeIf(Objects::isNull);
-        resetTiles(primitives);
-        this.invalidate();
+        if (MapRendererFactory.getInstance().isMapRendererActive(StyledTiledMapRenderer.class)) {
+            List<IPrimitive> primitives = new ArrayList<>(2);
+            primitives.add(e.getHoveredPrimitive());
+            primitives.add(e.getPreviousPrimitive());
+            primitives.removeIf(Objects::isNull);
+            resetTiles(primitives);
+            this.invalidate();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary

This partially fixes Ticket [#20366][josm-20366] wherein rendering is abysmally slow, especially on HiDPI systems. Current behavior uses a double-buffer strategy with `BufferedImage`s, forcing virtually all rendering into software loops.[^1] The bespoke HiDPI buffer scaling with `AffineTransforms` compounds this performance degradation.[^2] Performance seems to suffer exponentially with each additional layer regardless of its data; imagery tile layers seem to contribute the most.[^3]

I’ve switched the buffers to `VolatileImage`s, so the renderer can now defer to hardware routines where possible. This also defers HiDPI-scaling to the hardware surface, eliminating the need for the existing software one. The performance improvement is most obvious when running JOSM with a hardware-accelerated pipeline and

1. panning an non-trivial OSM data layer with labels disabled;
2. panning an arbitrary number of enabled imagery layers;
3. working with area fill enabled; or
4. working at high zoom levels.

This cannot convert some inherently software-based render operations like

- `Graphics2D` canvas/text anti-aliasing;
- `GlyphVector`-based text rendering; and
- alpha compositing (and whatever else I couldn’t find).

These ought to be refactored to take advantage of the equivalent hardware routines, if possible. If not, then the user should have finer control over these (e.g., rendering hints).

## Miscellanea

This also fixes a couple of performance regressions:

- `MapView` was marked as a transparent component; and
- hovering over an OSM primitive would immediately invalidate the layer, even if inactive

[josm-20366]: <https://josm.openstreetmap.de/ticket/20366> "#20366 (JOSM rendering is very slow especially on UHD displays)"
[oracle-primitive-tracing]: <https://docs.oracle.com/en/java/javase/24/troubleshoot/java-2d.html#GUID-35400B5A-A20D-4AFE-8A2C-1E1BD8AA5687> "Primitive Tracing to Detect and Avoid Non-Accelerated Rendering"

[^1]: See [Oracle docs][oracle-primitive-tracing].
[^2]: Incidentally, this is probably why the recommendation to run with `-Dsun.java2d.uiScale=1` was a suggested solution, since the resulting `AffineTransform` would’ve been the identity matrix.
[^3]: Stacking imagery layers very quickly destroys the frame rate.