### PR TITLE
Add fire_hydrant:diameter=500 to defaultpresets.xml

### DIFF
--- a/resources/data/defaultpresets.xml
+++ b/resources/data/defaultpresets.xml
@@ -4971,7 +4971,7 @@
                 <list_entry value="wall" short_description="A wall-mounted fire hydrant." />
                 <list_entry value="pipe" short_description="A simple capped pipe, without the usual hydrant shape." />
             </combo>
-            <combo key="fire_hydrant:diameter" text="Diameter (mm)" values="50,70,75,80,100,110,125,150,200,250,300,400" />
+            <combo key="fire_hydrant:diameter" text="Diameter (mm)" values="50,70,75,80,100,110,125,150,200,250,300,400,500" />
             <combo key="fire_hydrant:pressure" text="Pressure (bar) or suction" values_searchable="true" values_sort="false">
                 <list_entry value="#" short_description="Pressure in bar." />
                 <list_entry value="yes" short_description="Pressure but value unknown." />


### PR DESCRIPTION
I noticed that the validator was complaining about `500` being an unknown property value for `fire_hydrant:diameter`.

> Unknown property value - Value '500' for key 'fire_hydrant:diameter' is unknown, maybe one of [100, 200, 300, 400, 50] is meant? (2)

<img width="887" height="68" alt="image" src="https://github.com/user-attachments/assets/3cd7e1bb-ea99-4f48-99b6-6b7eadfc7eac" />

From looking at https://josm.openstreetmap.de/changeset/18352/josm and https://josm.openstreetmap.de/changeset/15465/josm, it seems like the way to fix that is to add the value to the default presets.